### PR TITLE
Fix empty pipeline bug

### DIFF
--- a/packages/pipeline-editor/src/PipelineController/index.ts
+++ b/packages/pipeline-editor/src/PipelineController/index.ts
@@ -49,7 +49,7 @@ class PipelineController extends CanvasController {
 
   open(pipelineJson: any) {
     // if pipeline is null create a new one from scratch.
-    if (pipelineJson === null) {
+    if (pipelineJson === undefined) {
       const emptyPipeline = this.getPipelineFlow();
       emptyPipeline.pipelines[0].app_data.version = PIPELINE_CURRENT_VERSION;
       this.setPipelineFlow(emptyPipeline);

--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -85,8 +85,8 @@ const PipelineEditor = forwardRef(
           controller.current.clearErrors();
         }
         // don't call to persist change because it will cause an infinate loop
-      } catch (error: any) {
-        onError?.(error);
+      } catch (e) {
+        onError?.(e);
       }
     }, [nodes, onChange, onError, pipeline, readOnly]);
 
@@ -154,7 +154,6 @@ const PipelineEditor = forwardRef(
         }
 
         if (e.editType === "createExternalNode") {
-          console.log(e);
           const nodeTemplate = controller.current.getPaletteNode(e.op);
           if (nodeTemplate) {
             const convertedTemplate = controller.current.convertNodeTemplate(


### PR DESCRIPTION
An empty pipeline will be `undefined` not `null` and `undefined !== null`

fixes: #24 