### PR TITLE
Fix node label look-and-feel

### DIFF
--- a/packages/pipeline-editor/src/PipelineController/index.ts
+++ b/packages/pipeline-editor/src/PipelineController/index.ts
@@ -203,7 +203,6 @@ class PipelineController extends CanvasController {
     const pipelineID = this.getPrimaryPipelineId();
     const linkToBeStyled = { [pipelineID]: linkIDs };
 
-    // @ts-ignore
     this.setLinksStyle(
       linkToBeStyled,
       {
@@ -220,8 +219,7 @@ class PipelineController extends CanvasController {
   }
 
   resetStyles() {
-    // @ts-ignore
-    this.removeAllStyles(false);
+    this.removeAllStyles();
 
     const pipelineID = this.getPrimaryPipelineId();
 

--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -484,7 +484,7 @@ const PipelineEditor = forwardRef(
               contextMenuHandler={() => {}}
               editActionHandler={() => {
                 controller.current.setPipelineFlow(pipeline);
-                controller.current.clearErrors();
+                controller.current.resetStyles();
               }}
               toolbarConfig={[]}
               config={{

--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -140,7 +140,7 @@ const PipelineEditor = forwardRef(
           controller.current.setNodes(nodes);
           controller.current.validate();
         } else {
-          controller.current.clearErrors();
+          controller.current.resetStyles();
         }
         // don't call to persist change because it will cause an infinate loop
       } catch (e) {

--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -523,6 +523,14 @@ const PipelineEditor = forwardRef(
                   enablePaletteLayout: "None", // 'Flyout', 'None', 'Modal'
                   enableNodeFormatType: "Horizontal",
                   enableToolbarLayout: toolbar === undefined ? "None" : "Top",
+                  enableNodeLayout: {
+                    imagePosX: 10,
+                    imagePosY: 0,
+                    imageWidth: 16,
+                    imageHeight: 40,
+                    labelPosX: 32,
+                    labelMaxWidth: 118,
+                  },
                 }}
                 notificationConfig={{ enable: false }}
                 contextMenuConfig={{

--- a/packages/pipeline-editor/src/common-canvas.d.ts
+++ b/packages/pipeline-editor/src/common-canvas.d.ts
@@ -127,6 +127,12 @@ declare module "@elyra/canvas" {
   function CommonProperties(props: any);
 
   class CanvasController {
+    setLinksStyle(
+      linkObjectIds: { [key: string]: string[] },
+      newStyle: unknown,
+      temporary: boolean
+    ): void;
+    removeAllStyles(temporary?: boolean): void;
     getPipelineFlow(): PipelineFlowV3;
     setPipelineFlow(pipelineFlow: PipelineFlowV3): void;
     getPrimaryPipelineId(): string;

--- a/packages/pipeline-editor/src/common-canvas.d.ts
+++ b/packages/pipeline-editor/src/common-canvas.d.ts
@@ -108,6 +108,12 @@ declare module "@elyra/canvas" {
       enableNodeLayout?: {
         bodyPath?: string;
         selectionPath?: string;
+        imagePosX?: number;
+        imagePosY?: number;
+        imageWidth?: number;
+        imageHeight?: number;
+        labelPosX?: number;
+        labelMaxWidth?: number;
       };
     };
     notificationConfig?: {

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -31,6 +31,7 @@
   font-family: var(--elyra-font-family-sans);
   fill: var(--elyra-color-button-text);
   transform: translate(-17px, 9px);
+  text-rendering: geometricPrecision;
 }
 
 /* ========================================================================== */
@@ -537,18 +538,14 @@
   rx: var(--elyra-border-radius);
 }
 
+.d3-node-label,
 .d3-supernode-label {
-  font-family: var(--elyra-font-family-mono);
-  font-weight: var(--elyra-font-weight-mono);
-  font-size: var(--elyra-font-size-mono);
+  font-family: var(--elyra-font-family-sans);
+  font-weight: var(--elyra-font-weight-sans);
+  font-size: var(--elyra-font-size-sans);
   fill: var(--elyra-color-node-text);
-}
-
-.d3-node-label {
-  font-family: var(--elyra-font-family-mono);
-  font-weight: var(--elyra-font-weight-mono);
-  font-size: var(--elyra-font-size-mono);
-  fill: var(--elyra-color-node-text);
+  font-weight: 500;
+  text-rendering: geometricPrecision;
 }
 
 .d3-comment-text-tspan {
@@ -556,6 +553,7 @@
   font-weight: var(--elyra-font-weight-sans) !important;
   font-size: var(--elyra-font-size-sans) !important;
   fill: var(--elyra-color-comment-text) !important;
+  text-rendering: geometricPrecision;
 }
 
 .d3-comment-entry {

--- a/packages/pipeline-services/src/index.ts
+++ b/packages/pipeline-services/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from "./migration";
-export * from "./validation";
+export { migrate } from "./migration";
+export { validate } from "./validation";

--- a/packages/pipeline-services/src/validation/index.spec.ts
+++ b/packages/pipeline-services/src/validation/index.spec.ts
@@ -332,9 +332,13 @@ const linkExamples = [
 
 describe("checkCircularReferences", () => {
   for (const { it: should, given, expected } of linkExamples) {
-    it(should, async () => {
+    it(should, () => {
+      const startTime = Date.now();
       const actual = checkCircularReferences(given);
+      const endTime = Date.now();
+
       expect(new Set(actual)).toEqual(new Set(expected));
+      expect(endTime - startTime).toBeLessThan(300);
     });
   }
 });

--- a/packages/pipeline-services/src/validation/index.ts
+++ b/packages/pipeline-services/src/validation/index.ts
@@ -77,11 +77,13 @@ export function checkCircularReferences(links: Link[]) {
           taintedLinks.add(item);
         }
 
-        // `position ?? 0` causes an infinite loop in some cases. No idea why...
-        const position = forkStack.pop();
+        // This is completely useless, but it makes me feel better that this is
+        // here.
+        const position = forkStack.slice(-1).pop();
         if (position !== undefined) {
           orderedChain = orderedChain.slice(0, position);
         }
+        // if position is undefined we will set orderedChain to []
         continue;
       }
 
@@ -91,8 +93,12 @@ export function checkCircularReferences(links: Link[]) {
 
       // We reached the end of a chain.
       if (linksToVisit === undefined) {
-        const position = forkStack.pop() ?? 0;
-        orderedChain = orderedChain.slice(0, position);
+        // This is 100% necessary unlike the other example.
+        const position = forkStack.slice(-1).pop();
+        if (position !== undefined) {
+          orderedChain = orderedChain.slice(0, position);
+        }
+        // if position is undefined we will set orderedChain to []
         continue;
       }
 


### PR DESCRIPTION
There was an issue with svg text-rendering for system-ui fonts, so we used the default monospace as an alternative.
This PR fixes the text rendering issue, so we can switch back to the sans font. I've also shrank the node icon to make it less huge. With the combination of the smaller icon and a non-monospaced font, we now have much more room for the label, making #34 basename vs with extension much less of an issue
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

