### PR TITLE
Make DCO a comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,28 +1,30 @@
+<!--
+Before submitting a pull request, please read:
+https://github.com/elyra-ai/community/blob/master/contributing.md
 
 
- 
 Developer's Certificate of Origin 1.1
 
-       By making a contribution to this project, I certify that:
+By making a contribution to this project, I certify that:
 
-       (a) The contribution was created in whole or in part by me and I
-           have the right to submit it under the Apache License 2.0; or
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the Apache License 2.0; or
 
-       (b) The contribution is based upon previous work that, to the best
-           of my knowledge, is covered under an appropriate open source
-           license and I have the right under that license to submit that
-           work with modifications, whether created in whole or in part
-           by me, under the same open source license (unless I am
-           permitted to submit under a different license), as indicated
-           in the file; or
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
 
-       (c) The contribution was provided directly to me by some other
-           person who certified (a), (b) or (c) and I have not modified
-           it.
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
 
-       (d) I understand and agree that this project and the contribution
-           are public and that a record of the contribution (including all
-           personal information I submit with it, including my sign-off) is
-           maintained indefinitely and may be redistributed consistent with
-           this project or the open source license(s) involved.
-
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+-->


### PR DESCRIPTION
Can we make the DCO a comment so it doesn't take up so much space? Similar to what Node.js does: https://raw.githubusercontent.com/nodejs/node/master/.github/PULL_REQUEST_TEMPLATE.md
 
<!--
Before submitting a pull request, please read:
https://github.com/elyra-ai/community/blob/master/contributing.md

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the Apache License 2.0; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->