### PR TITLE
Add onDoubleClickNode handler

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -50,6 +50,7 @@ interface Props {
   nodes?: any;
   onAction?: (action: { type: string; payload?: any }) => any;
   onChange?: (pipeline: any) => any;
+  onDoubleClickNode?: (e: CanvasClickEvent) => any;
   onError?: (error: Error) => any;
   onFileRequested?: (startPath?: string, multiselect?: boolean) => any;
   readOnly?: boolean;
@@ -113,6 +114,7 @@ const PipelineEditor = forwardRef(
       toolbar,
       onAction,
       onChange,
+      onDoubleClickNode,
       onError,
       onFileRequested,
       readOnly,
@@ -377,13 +379,19 @@ const PipelineEditor = forwardRef(
       []
     );
 
-    const handleClickAction = useCallback((e: CanvasClickEvent) => {
-      if (e.clickType === "DOUBLE_CLICK" && e.objectType === "node") {
-        // TODO: callback to let parent decide what to do instead.
-        setCurrentTab("properties");
-        controller.current.editActionHandler({ editType: "properties" });
-      }
-    }, []);
+    const handleClickAction = useCallback(
+      (e: CanvasClickEvent) => {
+        if (e.clickType === "DOUBLE_CLICK" && e.objectType === "node") {
+          if (onDoubleClickNode !== undefined) {
+            return onDoubleClickNode(e);
+          }
+          // TODO: callback to let parent decide what to do instead.
+          setCurrentTab("properties");
+          controller.current.editActionHandler({ editType: "properties" });
+        }
+      },
+      [onDoubleClickNode]
+    );
 
     const [selectedNodes, setSelectedNodes] = useState<NodeTypeDef[]>();
     const handleSelectionChange = useCallback((e: CanvasSelectionEvent) => {

--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -385,7 +385,6 @@ const PipelineEditor = forwardRef(
           if (onDoubleClickNode !== undefined) {
             return onDoubleClickNode(e);
           }
-          // TODO: callback to let parent decide what to do instead.
           setCurrentTab("properties");
           controller.current.editActionHandler({ editType: "properties" });
         }


### PR DESCRIPTION
if `onDoubleClickNode` handler is passed, call it instead of opening the properties editor

fixes: #69 

<!--
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
-->
