### PR TITLE
Add support for creating a node by right-clicking on canvas

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -271,7 +271,7 @@ const PipelineEditor = forwardRef(
             return [
               {
                 action: "newFileNode",
-                label: "New File Node",
+                label: "New Node from File",
               },
               {
                 action: "createComment",

--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import path from "path";
+
 import React, {
   forwardRef,
   useCallback,
@@ -54,7 +56,7 @@ interface Props {
   onChange?: (pipeline: any) => any;
   onDoubleClickNode?: (e: CanvasClickEvent) => any;
   onError?: (error: Error) => any;
-  onFileRequested?: (startPath?: string, multiselect?: boolean) => any;
+  onFileRequested?: (options: any) => any;
   readOnly?: boolean;
   children?: React.ReactNode;
   nativeKeyboardActions?: boolean;
@@ -226,23 +228,6 @@ const PipelineEditor = forwardRef(
           "expandSuperNodeInPlace"
         );
 
-        if (e.type === "canvas") {
-          return [
-            {
-              action: "createComment",
-              label: "New Comment",
-            },
-            {
-              divider: true,
-            },
-            {
-              action: "paste",
-              label: "Paste",
-              enable: canPaste,
-            },
-          ];
-        }
-
         if (e.selectedObjectIds.length > 1) {
           return [
             {
@@ -284,6 +269,10 @@ const PipelineEditor = forwardRef(
         switch (e.type) {
           case "canvas":
             return [
+              {
+                action: "newFileNode",
+                label: "New File Node",
+              },
               {
                 action: "createComment",
                 label: "New Comment",
@@ -460,6 +449,34 @@ const PipelineEditor = forwardRef(
         }
         onAction?.({ type: e.editType, payload });
 
+        if (e.editType === "newFileNode") {
+          const extensions = nodes.map((n: any) => n.extension);
+          const [file] = await onFileRequested?.({
+            canSelectMany: false,
+            filters: { Files: extensions },
+          });
+
+          const node = nodes.find(
+            (n: any) => n.extension === path.extname(file)
+          );
+
+          const nodeTemplate = controller.current.getPaletteNode(node.op);
+          if (nodeTemplate) {
+            const convertedTemplate = controller.current.convertNodeTemplate(
+              nodeTemplate
+            );
+            convertedTemplate.app_data.filename = file;
+            const action = {
+              editType: "createNode",
+              nodeTemplate: convertedTemplate,
+              pipelineId: e.pipelineId,
+              offsetX: e.mousePos.x,
+              offsetY: e.mousePos.y,
+            };
+            controller.current.editActionHandler(action);
+          }
+        }
+
         if (e.editType === "properties") {
           setCurrentTab("properties");
           setPanelOpen(true);
@@ -499,7 +516,7 @@ const PipelineEditor = forwardRef(
 
         onChange?.(controller.current.getPipelineFlow());
       },
-      [onAction, onChange]
+      [nodes, onAction, onChange, onFileRequested]
     );
 
     const handlePropertiesChange = useCallback(

--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -453,7 +453,7 @@ const PipelineEditor = forwardRef(
           const extensions = nodes.map((n: any) => n.extension);
           const [file] = await onFileRequested?.({
             canSelectMany: false,
-            filters: { Files: extensions },
+            filters: { File: extensions },
           });
 
           const node = nodes.find(


### PR DESCRIPTION
In VS Code there is no way to drag and drop files onto the canvas. This PR adds a convenient new way to add nodes to the canvas by right clicking on the canvas and selecting `New File Node`. This is similar to the `New Comment` option, but this will prompt the user to choose a file before creating the node. 

This is much quicker than the alternative of opening the palette, dragging on a python or notebook node, opening the properties, clicking `browse`, then choose the file.

Fixes: #82 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

