### PR TITLE
Fix value persistence when `current_parameters` is undefined for that key

### DIFF
--- a/packages/pipeline-editor/src/PropertiesPanel/properties-utils.test.ts
+++ b/packages/pipeline-editor/src/PropertiesPanel/properties-utils.test.ts
@@ -17,7 +17,7 @@
 import { fillPropertiesWithSavedData } from "./properties-utils";
 
 describe("fillPropertiesWithSavedData", () => {
-  it("should fill properties that are not defined in schema", () => {
+  it("should fill properties that are not explicitly defined in the defaults", () => {
     const defaults = {
       current_parameters: {
         filename: "",

--- a/packages/pipeline-editor/src/PropertiesPanel/properties-utils.test.ts
+++ b/packages/pipeline-editor/src/PropertiesPanel/properties-utils.test.ts
@@ -17,7 +17,7 @@
 import { fillPropertiesWithSavedData } from "./properties-utils";
 
 describe("fillPropertiesWithSavedData", () => {
-  it("should not fill properties that are not defined in schema", () => {
+  it("should fill properties that are not defined in schema", () => {
     const defaults = {
       current_parameters: {
         filename: "",
@@ -30,6 +30,7 @@ describe("fillPropertiesWithSavedData", () => {
     };
     const result = fillPropertiesWithSavedData(defaults, { bloop: "hello" });
     expect(result.current_parameters).toEqual({
+      bloop: "hello",
       filename: "",
       runtime_image: "",
       dependencies: [],

--- a/packages/pipeline-editor/src/PropertiesPanel/properties-utils.ts
+++ b/packages/pipeline-editor/src/PropertiesPanel/properties-utils.ts
@@ -66,11 +66,7 @@ export function fillPropertiesWithSavedData(
 ) {
   return produce(properties, (draftState) => {
     for (const [key, val] of Object.entries(appData)) {
-      if (
-        val !== undefined &&
-        val !== null &&
-        draftState.current_parameters.hasOwnProperty(key)
-      ) {
+      if (val !== undefined && val !== null) {
         draftState.current_parameters[key] = val;
       }
     }


### PR DESCRIPTION
fixes: #107 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

