### PR TITLE
Update README to remove broken instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,11 @@ limitations under the License.
 `@elyra/pipeline-editor` is available as an [npm package](https://www.npmjs.com/package/@elyra/pipeline-editor):
 
 ```sh
-// npm
+# npm
 npm install @elyra/pipeline-editor
 
-// yarn
+# yarn
 yarn add @elyra/pipeline-editor
-```
-
-Or can be linked locally:
-
-```sh
-git clone git@github.com:elyra-ai/pipeline-editor.git
-cd pipeline-editor
-
-make clean install link
 ```
 
 ## Usage


### PR DESCRIPTION
The README currently has instructions for locally linking the package, but doesn't actually work.

This is just an initial step in revamping the documentation for `pipeline-editor`.  Before continuing we need to consolidate commands into `make` or `npm scripts`.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

