### PR TITLE
Support a list of extensions for file nodes

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -453,14 +453,15 @@ const PipelineEditor = forwardRef(
         onAction?.({ type: e.editType, payload });
 
         if (e.editType === "newFileNode") {
-          const extensions = nodes.map((n: any) => n.extension);
+          const extensions = nodes.map((n: any) => n.extensions).flat();
+
           const [file] = await onFileRequested?.({
             canSelectMany: false,
             filters: { File: extensions },
           });
 
-          const node = nodes.find(
-            (n: any) => n.extension === path.extname(file)
+          const node = nodes.find((n: any) =>
+            n.extensions.includes(path.extname(file))
           );
 
           const nodeTemplate = controller.current.getPaletteNode(node.op);


### PR DESCRIPTION
**breaking change** 

The schema for file nodes has changed a bit:
- `fileBased` has been deprecated in favor of a `type` string for more flexibility in the future (no code change has been made, but going forward `type` may be expected)
- `extension` MUST be changed to an `extensions` list

```diff
const node = {
  op: 'execute-notebook-node',
  description: 'Notebook file',
  label: 'Notebook',
- fileBased: true,
- extension: '.ipynb',
+ type: "file",
+ extensions: ['.ipynb'],
  ...
}
```

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

