### PR TITLE
Choose tab based on pipeline state

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -493,6 +493,15 @@ const PipelineEditor = forwardRef(
         }
 
         if (e.editType === "toggleOpenPanel") {
+          if (!panelOpen) {
+            let defaultTab = "palette";
+            if (e.selectedObjectIds.length > 0) {
+              defaultTab = "properties";
+            } else if (controller.current.getNodes().length > 0) {
+              defaultTab = "pipeline-properties";
+            }
+            setCurrentTab(defaultTab);
+          }
           setPanelOpen((prev) => !prev);
         }
 
@@ -684,6 +693,7 @@ const PipelineEditor = forwardRef(
                   {
                     id: "pipeline-properties",
                     label: "Pipeline Properties",
+                    tooltip: "Edit pipeline properties",
                     icon: theme.overrides?.pipelineIcon,
                     content: (
                       <PipelineProperties
@@ -700,6 +710,7 @@ const PipelineEditor = forwardRef(
                   {
                     id: "properties",
                     label: "Node Properties",
+                    tooltip: "Edit node properties",
                     icon: theme.overrides?.propertiesIcon,
                     content: (
                       <NodeProperties
@@ -716,6 +727,7 @@ const PipelineEditor = forwardRef(
                   {
                     id: "palette",
                     label: "Palette",
+                    tooltip: "Add nodes to pipeline",
                     icon: theme.overrides?.paletteIcon,
                     content: <PalettePanel nodes={nodes} />,
                   },

--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -535,7 +535,14 @@ const PipelineEditor = forwardRef(
 
         onChange?.(controller.current.getPipelineFlow());
       },
-      [nodes, onAction, onChange, onFileRequested, onPropertiesUpdateRequested]
+      [
+        nodes,
+        onAction,
+        onChange,
+        onFileRequested,
+        onPropertiesUpdateRequested,
+        panelOpen,
+      ]
     );
 
     const handlePropertiesChange = useCallback(
@@ -693,7 +700,7 @@ const PipelineEditor = forwardRef(
                   {
                     id: "pipeline-properties",
                     label: "Pipeline Properties",
-                    tooltip: "Edit pipeline properties",
+                    title: "Edit pipeline properties",
                     icon: theme.overrides?.pipelineIcon,
                     content: (
                       <PipelineProperties
@@ -710,7 +717,7 @@ const PipelineEditor = forwardRef(
                   {
                     id: "properties",
                     label: "Node Properties",
-                    tooltip: "Edit node properties",
+                    title: "Edit node properties",
                     icon: theme.overrides?.propertiesIcon,
                     content: (
                       <NodeProperties
@@ -727,7 +734,7 @@ const PipelineEditor = forwardRef(
                   {
                     id: "palette",
                     label: "Palette",
-                    tooltip: "Add nodes to pipeline",
+                    title: "Add nodes to pipeline",
                     icon: theme.overrides?.paletteIcon,
                     content: <PalettePanel nodes={nodes} />,
                   },

--- a/packages/pipeline-editor/src/TabbedPanelLayout/index.tsx
+++ b/packages/pipeline-editor/src/TabbedPanelLayout/index.tsx
@@ -24,7 +24,7 @@ interface Props {
   tabs: {
     id: string;
     label: string;
-    tooltip: string;
+    title: string;
     icon?: React.ReactNode;
     content: React.ReactNode;
   }[];
@@ -161,7 +161,7 @@ function TabbedPanelLayout({
           {tabs.map((t) => (
             <Tab key={t.id}>
               <Label
-                title={t.tooltip}
+                title={t.title}
                 active={resolvedCurrentTab === t.id}
                 onClick={() => {
                   onTabClick?.(t.id);

--- a/packages/pipeline-editor/src/TabbedPanelLayout/index.tsx
+++ b/packages/pipeline-editor/src/TabbedPanelLayout/index.tsx
@@ -24,6 +24,7 @@ interface Props {
   tabs: {
     id: string;
     label: string;
+    tooltip: string;
     icon?: React.ReactNode;
     content: React.ReactNode;
   }[];
@@ -160,6 +161,7 @@ function TabbedPanelLayout({
           {tabs.map((t) => (
             <Tab key={t.id}>
               <Label
+                title={t.tooltip}
                 active={resolvedCurrentTab === t.id}
                 onClick={() => {
                   onTabClick?.(t.id);

--- a/packages/pipeline-editor/src/TabbedPanelLayout/index.tsx
+++ b/packages/pipeline-editor/src/TabbedPanelLayout/index.tsx
@@ -24,7 +24,7 @@ interface Props {
   tabs: {
     id: string;
     label: string;
-    title: string;
+    title?: string;
     icon?: React.ReactNode;
     content: React.ReactNode;
   }[];


### PR DESCRIPTION
Currently the side bar always opens to the first tab.

This changes behavior to the following:
- empty pipline -> open pallete tab
- selected nodes -> open node properties
- non-empty with nothing selected -> open pipeline properties

This also adds tooltips for the tabs

Fixes https://github.com/elyra-ai/elyra/issues/1746

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

