### PR TITLE
Default to current parameters in tooltip

### DIFF
--- a/packages/pipeline-editor/src/PipelineController/index.ts
+++ b/packages/pipeline-editor/src/PipelineController/index.ts
@@ -454,7 +454,7 @@ class PipelineController extends CanvasController {
       const properties = info.map((i) => {
         return {
           label: i.label.default,
-          // `app_data` should never be undefined because canvas injects it.
+          // Use the current parameters as a default if `app_data` doesn't have a value.
           value:
             app_data?.[i.parameter_ref] ??
             nodeDef?.properties?.current_parameters?.[i.parameter_ref],

--- a/packages/pipeline-editor/src/PipelineController/index.ts
+++ b/packages/pipeline-editor/src/PipelineController/index.ts
@@ -455,7 +455,9 @@ class PipelineController extends CanvasController {
         return {
           label: i.label.default,
           // `app_data` should never be undefined because canvas injects it.
-          value: app_data![i.parameter_ref],
+          value:
+            app_data?.[i.parameter_ref] ??
+            nodeDef?.properties?.current_parameters?.[i.parameter_ref],
         };
       });
       return properties;


### PR DESCRIPTION
Fixes elyra-ai/elyra#1769. Uses the default value of a parameter if none is defined in `app_data`. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

