### PR TITLE
Prevent crash when pipeline is cleared and pipeline properties is open

### DIFF
--- a/packages/pipeline-editor/src/properties-panels/PipelineProperties.tsx
+++ b/packages/pipeline-editor/src/properties-panels/PipelineProperties.tsx
@@ -44,7 +44,7 @@ function PipelineProperties({
       propertiesSchema={propertiesSchema}
       onFileRequested={onFileRequested}
       onChange={onChange}
-      id={pipelineFlow.id}
+      id={pipelineFlow?.id}
     />
   );
 }


### PR DESCRIPTION
Fixes pipeline properties accessing the `id` field of the `pipelineFlow` field when it is possibly null.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

