### PR TITLE
Update side panel tab dynamically

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -428,13 +428,22 @@ const PipelineEditor = forwardRef(
       []
     );
 
+    const setPropertiesTab = (nodesSelected: boolean) => {
+      if (nodesSelected) {
+        setCurrentTab("properties");
+      } else if (controller.current.getNodes().length > 0) {
+        setCurrentTab("pipeline-properties");
+      } else {
+        setCurrentTab("palette");
+      }
+    };
+
     const handleClickAction = useCallback(
       (e: CanvasClickEvent) => {
         if (e.clickType === "DOUBLE_CLICK" && e.objectType === "node") {
           if (onDoubleClickNode !== undefined) {
             return onDoubleClickNode(e);
           }
-          setCurrentTab("properties");
           controller.current.editActionHandler({ editType: "properties" });
         }
       },
@@ -444,6 +453,7 @@ const PipelineEditor = forwardRef(
     const [selectedNodeIDs, setSelectedNodeIDs] = useState<string[]>();
     const handleSelectionChange = useCallback((e: CanvasSelectionEvent) => {
       setSelectedNodeIDs(e.selectedNodes.map((n: NodeTypeDef) => n.id));
+      setPropertiesTab(e.selectedNodes.length > 0);
     }, []);
 
     const handleEditAction = useCallback(
@@ -481,15 +491,6 @@ const PipelineEditor = forwardRef(
         }
 
         if (e.editType === "toggleOpenPanel") {
-          if (!panelOpen) {
-            let defaultTab = "palette";
-            if (e.selectedObjectIds.length > 0) {
-              defaultTab = "properties";
-            } else if (controller.current.getNodes().length > 0) {
-              defaultTab = "pipeline-properties";
-            }
-            setCurrentTab(defaultTab);
-          }
           setPanelOpen((prev) => !prev);
         }
 
@@ -516,7 +517,7 @@ const PipelineEditor = forwardRef(
 
         onChange?.(controller.current.getPipelineFlow());
       },
-      [nodes, onAction, onChange, onFileRequested, panelOpen]
+      [nodes, onAction, onChange, onFileRequested]
     );
 
     const handlePropertiesChange = useCallback(

--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -428,16 +428,6 @@ const PipelineEditor = forwardRef(
       []
     );
 
-    const setPropertiesTab = (nodesSelected: boolean) => {
-      if (nodesSelected) {
-        setCurrentTab("properties");
-      } else if (controller.current.getNodes().length > 0) {
-        setCurrentTab("pipeline-properties");
-      } else {
-        setCurrentTab("palette");
-      }
-    };
-
     const handleClickAction = useCallback(
       (e: CanvasClickEvent) => {
         if (e.clickType === "DOUBLE_CLICK" && e.objectType === "node") {
@@ -453,7 +443,13 @@ const PipelineEditor = forwardRef(
     const [selectedNodeIDs, setSelectedNodeIDs] = useState<string[]>();
     const handleSelectionChange = useCallback((e: CanvasSelectionEvent) => {
       setSelectedNodeIDs(e.selectedNodes.map((n: NodeTypeDef) => n.id));
-      setPropertiesTab(e.selectedNodes.length > 0);
+      if (e.selectedNodes.length > 0) {
+        setCurrentTab("properties");
+      } else if (controller.current.getNodes().length > 0) {
+        setCurrentTab("pipeline-properties");
+      } else {
+        setCurrentTab("palette");
+      }
     }, []);
 
     const handleEditAction = useCallback(


### PR DESCRIPTION
Currently the side panel tab is only set when opening the panel.

This changes it to update the tab whenever the selected nodes change,
following the same rules as it previously used when opening the panel.

Fixes https://github.com/elyra-ai/elyra/issues/1827



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

