### PR TITLE
Copy node properties defaults when creating a new node

### DIFF
--- a/packages/pipeline-editor/src/PipelineController/index.ts
+++ b/packages/pipeline-editor/src/PipelineController/index.ts
@@ -125,13 +125,6 @@ class PipelineController extends CanvasController {
       pipelineId: item.pipelineId,
     };
 
-    const nodeDef = this.getAllPaletteNodes().find((n) => n.op === item.op);
-    if (nodeDef?.app_data.properties?.current_parameters) {
-      data.nodeTemplate.app_data = {
-        ...nodeDef?.app_data.properties?.current_parameters,
-      };
-    }
-
     if (item.path) {
       data.nodeTemplate.app_data.filename = item.path;
       const properties = await item.onPropertiesUpdateRequested?.({

--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -511,6 +511,17 @@ const PipelineEditor = forwardRef(
           });
         }
 
+        if (e.editType === "createNode") {
+          const nodeDef = controller.current
+            .getAllPaletteNodes()
+            .find((n) => n.op === e.newNode?.op);
+          if (nodeDef?.app_data.properties?.current_parameters) {
+            e.newNode.app_data = {
+              ...nodeDef?.app_data.properties?.current_parameters,
+            };
+          }
+        }
+
         // Catch any events where a save isn't necessary.
         switch (e.editType) {
           case "properties":


### PR DESCRIPTION
Fixes elyra-ai/elyra#1877. Copies over the node properties defaults when creating a new node - same changes as #133, but handling the left palette node creation. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

