### PR TITLE
Add component type as heading to properties editor / node tooltip

### DIFF
--- a/packages/pipeline-editor/src/NodeTooltip/index.test.tsx
+++ b/packages/pipeline-editor/src/NodeTooltip/index.test.tsx
@@ -19,10 +19,14 @@ import NodeTooltip from "./";
 
 it("renders one item", () => {
   const { container } = render(
-    <NodeTooltip properties={[{ label: "Label", value: "some value" }]} />
+    <NodeTooltip
+      properties={[{ label: "Label", value: "some value" }]}
+      nodeLabel="Component Type"
+    />
   );
   expect(container.firstChild).toHaveTextContent(/label/i);
   expect(container.firstChild).toHaveTextContent(/some value/i);
+  expect(container.firstChild).toHaveTextContent(/component type/i);
 });
 
 it("renders multiple items", () => {
@@ -32,11 +36,13 @@ it("renders multiple items", () => {
         { label: "Label", value: "some value" },
         { label: "Array", value: ["one", "two"] },
       ]}
+      nodeLabel="Component Type"
     />
   );
 
   expect(container.firstChild).toHaveTextContent(/label/i);
   expect(container.firstChild).toHaveTextContent(/some value/i);
+  expect(container.firstChild).toHaveTextContent(/component type/i);
 
   expect(container.firstChild).toHaveTextContent(/array/i);
   expect(container.firstChild).toHaveTextContent(/one/i);
@@ -45,11 +51,16 @@ it("renders multiple items", () => {
 
 it("renders with errors", () => {
   const { container } = render(
-    <NodeTooltip error="this is an error" properties={[]} />
+    <NodeTooltip
+      error="this is an error"
+      properties={[]}
+      nodeLabel="Component type"
+    />
   );
 
   expect(container.firstChild).toHaveTextContent(/error/i);
   expect(container.firstChild).toHaveTextContent(/this is an error/i);
+  expect(container.firstChild).toHaveTextContent(/component type/i);
 });
 
 it("renders with errors and properties", () => {

--- a/packages/pipeline-editor/src/NodeTooltip/index.tsx
+++ b/packages/pipeline-editor/src/NodeTooltip/index.tsx
@@ -20,6 +20,7 @@ import { hasValue, toPrettyString } from "./utils";
 
 interface Props {
   error?: string;
+  nodeLabel?: string;
   properties: {
     label: string;
     value: any;
@@ -46,7 +47,7 @@ const ErrorValue = styled(Value)`
   color: ${({ theme }) => theme.palette.text.error};
 `;
 
-function NodeTooltip({ error, properties }: Props) {
+function NodeTooltip({ error, nodeLabel, properties }: Props) {
   return (
     <Container>
       {error && (
@@ -55,6 +56,7 @@ function NodeTooltip({ error, properties }: Props) {
           <ErrorValue>{toPrettyString(error)}</ErrorValue>
         </div>
       )}
+      <Key>{nodeLabel}</Key>
       {properties
         .filter(({ value }) => hasValue(value))
         .map(({ label, value }) => (

--- a/packages/pipeline-editor/src/PipelineController/index.test.ts
+++ b/packages/pipeline-editor/src/PipelineController/index.test.ts
@@ -1073,7 +1073,7 @@ describe("resetStyles", () => {
 
     const flow = controller.getPipelineFlow();
     expect(flow.pipelines[0].nodes[0].app_data?.ui_data?.label).toBe(
-      "Notebook"
+      "Notebook Label"
     );
   });
 

--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -572,12 +572,14 @@ const PipelineEditor = forwardRef(
       if (isNodeTipEvent(tipType, e) && e.node.type === "execution_node") {
         const error = e.node.app_data.invalidNodeError;
         const properties = controller.current.properties(e.node.id);
-        const node: any = controller.current.getPaletteNode(e.node.op);
+        const node = controller.current
+          .getAllPaletteNodes()
+          .find((n) => n.op === e.node.op);
         return (
           <NodeTooltip
             error={error}
             properties={properties}
-            nodeLabel={node.label}
+            nodeLabel={node?.label}
           />
         );
       }

--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -572,7 +572,14 @@ const PipelineEditor = forwardRef(
       if (isNodeTipEvent(tipType, e) && e.node.type === "execution_node") {
         const error = e.node.app_data.invalidNodeError;
         const properties = controller.current.properties(e.node.id);
-        return <NodeTooltip error={error} properties={properties} />;
+        const node: any = controller.current.getPaletteNode(e.node.op);
+        return (
+          <NodeTooltip
+            error={error}
+            properties={properties}
+            nodeLabel={node.label}
+          />
+        );
       }
       if (isNodeTipEvent(tipType, e) && e.node.type === "super_node") {
         // TODO: Can we can sub node errors propagated up?

--- a/packages/pipeline-editor/src/ThemeProvider/styles.ts
+++ b/packages/pipeline-editor/src/ThemeProvider/styles.ts
@@ -198,10 +198,6 @@ export const CanvasOverrides = css`
     padding: 0;
   }
 
-  .properties-wrapper {
-    margin-top: 14px;
-  }
-
   .properties-editor-form
     .properties-control-panel
     > .properties-control-panel {

--- a/packages/pipeline-editor/src/common-canvas.d.ts
+++ b/packages/pipeline-editor/src/common-canvas.d.ts
@@ -2409,6 +2409,10 @@ declare module "@elyra/canvas" {
        */
       type: "execution_node";
       /**
+       * Label used for displaying node
+       */
+      label?: string;
+      /**
        * Operator type identifier
        */
       op: string;

--- a/packages/pipeline-editor/src/properties-panels/NodeProperties.tsx
+++ b/packages/pipeline-editor/src/properties-panels/NodeProperties.tsx
@@ -22,7 +22,7 @@ interface Props {
   selectedNodes?: any[];
   nodes: {
     op: string;
-    label: string;
+    label?: string;
     app_data: {
       properties?: any;
     };

--- a/packages/pipeline-editor/src/properties-panels/NodeProperties.tsx
+++ b/packages/pipeline-editor/src/properties-panels/NodeProperties.tsx
@@ -84,7 +84,7 @@ function NodeProperties({
 
   return (
     <div>
-      <Heading> {nodePropertiesSchema.label} </Heading>
+      <Heading>{nodePropertiesSchema.label}</Heading>
       <PropertiesPanel
         currentProperties={selectedNode.app_data}
         onPropertiesUpdateRequested={onPropertiesUpdateRequested}

--- a/packages/pipeline-editor/src/properties-panels/NodeProperties.tsx
+++ b/packages/pipeline-editor/src/properties-panels/NodeProperties.tsx
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
+import styled from "styled-components";
+
 import { PropertiesPanel, Message } from "./PropertiesPanel";
 
 interface Props {
   selectedNodes?: any[];
   nodes: {
     op: string;
+    label: string;
     app_data: {
       properties?: any;
     };
@@ -28,6 +31,16 @@ interface Props {
   onPropertiesUpdateRequested?: (options: any) => any;
   onChange?: (nodeID: string, data: any) => any;
 }
+
+const Heading = styled.div`
+  margin-top: 14px;
+  padding: 0 47px;
+  font-family: ${({ theme }) => theme.typography.fontFamily};
+  font-weight: ${({ theme }) => theme.typography.fontWeight};
+  font-size: 16px;
+  color: ${({ theme }) => theme.palette.text.primary};
+  opacity: 0.5;
+`;
 
 function NodeProperties({
   selectedNodes,
@@ -70,16 +83,19 @@ function NodeProperties({
   }
 
   return (
-    <PropertiesPanel
-      currentProperties={selectedNode.app_data}
-      onPropertiesUpdateRequested={onPropertiesUpdateRequested}
-      propertiesSchema={nodePropertiesSchema.app_data.properties}
-      onFileRequested={onFileRequested}
-      onChange={(data: any) => {
-        onChange?.(selectedNode.id, data);
-      }}
-      id={selectedNode.id}
-    />
+    <div>
+      <Heading> {nodePropertiesSchema.label} </Heading>
+      <PropertiesPanel
+        currentProperties={selectedNode.app_data}
+        onPropertiesUpdateRequested={onPropertiesUpdateRequested}
+        propertiesSchema={nodePropertiesSchema.app_data.properties}
+        onFileRequested={onFileRequested}
+        onChange={(data: any) => {
+          onChange?.(selectedNode.id, data);
+        }}
+        id={selectedNode.id}
+      />
+    </div>
   );
 }
 

--- a/packages/pipeline-editor/src/properties-panels/index.test.tsx
+++ b/packages/pipeline-editor/src/properties-panels/index.test.tsx
@@ -77,6 +77,7 @@ it("renders common properties with one node selected", () => {
       <NodeProperties nodes={[nodes]} selectedNodes={[selectedNode]} />
     </IntlProvider>
   );
+  expect(screen.getByText(/notebook label/i)).toBeInTheDocument();
   expect(screen.getByLabelText(/properties/i)).toBeInTheDocument();
 });
 

--- a/packages/pipeline-editor/src/test-utils.tsx
+++ b/packages/pipeline-editor/src/test-utils.tsx
@@ -31,7 +31,7 @@ interface CustomNodeSpecification {
 export const nodeSpec: CustomNodeSpecification = {
   op: "execute-notebook-node",
   description: "Notebook file",
-  label: "Notebook",
+  label: "Notebook Label",
   extensions: [".ipynb"],
   image: undefined,
   properties: {
@@ -348,6 +348,7 @@ function createPalette(nodes: CustomNodeSpecification[]): PaletteV3 {
       op,
       description,
       id: "",
+      label: label,
       type: "execution_node",
       inputs: [
         {


### PR DESCRIPTION
Fixes elyra-ai/elyra#1836. Adds component type to the top of the node properties editor so that user can see the component type being edited. 
![image](https://user-images.githubusercontent.com/6673460/125110490-3bf66e00-e0aa-11eb-81c6-11dd0c3bbc90.png) 
![image](https://user-images.githubusercontent.com/6673460/125110589-62b4a480-e0aa-11eb-8a94-e8f65f057250.png)

Also adds component type to the top of the tooltip:
![image](https://user-images.githubusercontent.com/6673460/125119550-e1afda00-e0b6-11eb-82d1-e0b8b877226b.png)

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

