### PR TITLE
Add separate error case for missing component def

### DIFF
--- a/packages/pipeline-editor/src/properties-panels/NodeProperties.tsx
+++ b/packages/pipeline-editor/src/properties-panels/NodeProperties.tsx
@@ -82,6 +82,18 @@ function NodeProperties({
 
   const nodePropertiesSchema = nodes.find((n) => n.op === selectedNode.op);
 
+  if (nodePropertiesSchema === undefined) {
+    return (
+      <Message>
+        This node uses a component that is not stored in your component
+        registry.
+        {selectedNode.app_data.component_source !== undefined
+          ? ` The component's path is: ${selectedNode.app_data.component_source}`
+          : ""}
+      </Message>
+    );
+  }
+
   if (nodePropertiesSchema?.app_data.properties === undefined) {
     return (
       <Message>This node type doesn't have any editable properties.</Message>

--- a/packages/pipeline-editor/src/properties-panels/index.test.tsx
+++ b/packages/pipeline-editor/src/properties-panels/index.test.tsx
@@ -67,7 +67,7 @@ it("renders if selected node op isn't defined in schema", () => {
     <NodeProperties nodes={[]} selectedNodes={[selectedNode]} />
   );
   expect(container.firstChild).toHaveTextContent(
-    /this node type doesn't have any editable properties/i
+    /This node uses a component that is not stored in your component registry/i
   );
 });
 


### PR DESCRIPTION
Currently if a component for a node is not found in the registry
then it show's a "this node has no properties" message. This is not
exactly the most accurate messaging here. This adds better messaging
for that case.

Fixes https://github.com/elyra-ai/elyra/issues/2188



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

