### PR TITLE
Add OneOfControl for properties with multiple types

### DIFF
--- a/packages/pipeline-editor/src/CustomFormControls/BooleanControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/BooleanControl.tsx
@@ -56,7 +56,7 @@ const Checkbox = styled.div<{ isChecked: boolean }>`
   }
 `;
 
-function BooleanControl({ description }: Props) {
+export function BooleanControlRaw({ description }: Props) {
   const theme = useTheme();
 
   const [isChecked = false, setIsChecked] = useControlState<boolean>();
@@ -82,4 +82,4 @@ function BooleanControl({ description }: Props) {
   );
 }
 
-export default createControl("BooleanControl", BooleanControl);
+export default createControl("BooleanControl", BooleanControlRaw);

--- a/packages/pipeline-editor/src/CustomFormControls/BooleanControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/BooleanControl.tsx
@@ -56,7 +56,7 @@ const Checkbox = styled.div<{ isChecked: boolean }>`
   }
 `;
 
-export function BooleanControlRaw({ description }: Props) {
+export function BooleanControl({ description }: Props) {
   const theme = useTheme();
 
   const [isChecked = false, setIsChecked] = useControlState<boolean>();
@@ -82,4 +82,4 @@ export function BooleanControlRaw({ description }: Props) {
   );
 }
 
-export default createControl("BooleanControl", BooleanControlRaw);
+export default createControl("BooleanControl", BooleanControl);

--- a/packages/pipeline-editor/src/CustomFormControls/DisplayControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/DisplayControl.tsx
@@ -16,10 +16,10 @@
 
 import { createControl, useControlState } from "./control";
 
-function DisplayControl() {
+export function DisplayControlRaw() {
   const [value] = useControlState<string>();
 
   return <p>{value}</p>;
 }
 
-export default createControl("DisplayControl", DisplayControl);
+export default createControl("DisplayControl", DisplayControlRaw);

--- a/packages/pipeline-editor/src/CustomFormControls/DisplayControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/DisplayControl.tsx
@@ -16,10 +16,10 @@
 
 import { createControl, useControlState } from "./control";
 
-export function DisplayControlRaw() {
+export function DisplayControl() {
   const [value] = useControlState<string>();
 
   return <p>{value}</p>;
 }
 
-export default createControl("DisplayControl", DisplayControlRaw);
+export default createControl("DisplayControl", DisplayControl);

--- a/packages/pipeline-editor/src/CustomFormControls/EnumControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/EnumControl.tsx
@@ -33,7 +33,7 @@ interface Props {
   items: string[];
 }
 
-function EnumControl({ items }: Props) {
+export function EnumControlRaw({ items }: Props) {
   const [value, setValue] = useControlState<string>();
 
   const theme = useTheme();
@@ -80,4 +80,4 @@ function EnumControl({ items }: Props) {
   );
 }
 
-export default createControl("EnumControl", EnumControl);
+export default createControl("EnumControl", EnumControlRaw);

--- a/packages/pipeline-editor/src/CustomFormControls/EnumControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/EnumControl.tsx
@@ -33,7 +33,7 @@ interface Props {
   items: string[];
 }
 
-export function EnumControlRaw({ items }: Props) {
+export function EnumControl({ items }: Props) {
   const [value, setValue] = useControlState<string>();
 
   const theme = useTheme();
@@ -80,4 +80,4 @@ export function EnumControlRaw({ items }: Props) {
   );
 }
 
-export default createControl("EnumControl", EnumControlRaw);
+export default createControl("EnumControl", EnumControl);

--- a/packages/pipeline-editor/src/CustomFormControls/NestedEnumControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/NestedEnumControl.tsx
@@ -70,8 +70,15 @@ function flatten(data: Data[], allowNoOptions: boolean): any[] {
   return flattenedData;
 }
 
-function getLabel(value: FlatData, data: Data[], placeholder: string): string {
-  const entry = data.find((item) => item.value === value?.value);
+function getLabel(
+  value: FlatData | undefined,
+  data: Data[],
+  placeholder: string
+): string {
+  if (!value) {
+    return placeholder;
+  }
+  const entry = data.find((item) => item.value === value.value);
   const option = entry?.options?.find((opt) => opt.value === value.option);
   return entry
     ? entry.label + (option ? ": " + option?.label : "")
@@ -122,15 +129,19 @@ export function NestedEnumControl({
     onSelectedItemChange: handleSelectedItemChange,
   });
 
-  const validators = getNestedEnumValidators({ data, required });
+  const validators = getNestedEnumValidators({
+    data,
+    allowNoOptions,
+    required,
+  });
 
-  let errorMessages = required ? getErrorMessages(value, validators) : [];
+  const errorMessages = required ? getErrorMessages(value, validators) : [];
 
   return (
     <div className={errorMessages.length > 0 ? "error" : undefined}>
       <EnumContainer isOpen={isOpen}>
         <EnumButton {...getToggleButtonProps()}>
-          <EnumLabel>{getLabel(selectedItem, data, placeholder)}</EnumLabel>
+          <EnumLabel>{getLabel(value, data, placeholder)}</EnumLabel>
           <EnumIcon className="elyricon elyricon-chevron-down">
             {theme.overrides?.chevronDownIcon}
           </EnumIcon>

--- a/packages/pipeline-editor/src/CustomFormControls/NestedEnumControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/NestedEnumControl.tsx
@@ -78,7 +78,7 @@ function getLabel(value: FlatData, data: Data[], placeholder: string): string {
     : placeholder;
 }
 
-export function NestedEnumControlRaw({
+export function NestedEnumControl({
   data = [],
   placeholder = "Select a value",
   allowNoOptions = false,
@@ -154,4 +154,4 @@ export function NestedEnumControlRaw({
   );
 }
 
-export default createControl("NestedEnumControl", NestedEnumControlRaw);
+export default createControl("NestedEnumControl", NestedEnumControl);

--- a/packages/pipeline-editor/src/CustomFormControls/NestedEnumControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/NestedEnumControl.tsx
@@ -45,12 +45,13 @@ export interface FlatData {
 }
 
 interface Props {
-  data: Data[];
-  placeholder: string;
+  data?: Data[];
+  placeholder?: string;
+  allowNoOptions?: boolean;
   required?: boolean;
 }
 
-function flatten(data: Data[]): any[] {
+function flatten(data: Data[], allowNoOptions: boolean): any[] {
   let flattenedData: FlatData[] = [];
   data.forEach((item: Data) => {
     item.options?.forEach((option: Data) => {
@@ -59,6 +60,12 @@ function flatten(data: Data[]): any[] {
         option: option.value,
       });
     });
+    if (allowNoOptions && (!item.options || item.options.length === 0)) {
+      flattenedData.push({
+        value: item.value,
+        option: "",
+      });
+    }
   });
   return flattenedData;
 }
@@ -66,19 +73,22 @@ function flatten(data: Data[]): any[] {
 function getLabel(value: FlatData, data: Data[], placeholder: string): string {
   const entry = data.find((item) => item.value === value?.value);
   const option = entry?.options?.find((opt) => opt.value === value.option);
-  return entry && option ? entry.label + ": " + option.label : placeholder;
+  return entry
+    ? entry.label + (option ? ": " + option?.label : "")
+    : placeholder;
 }
 
-function NestedEnumControl({
+export function NestedEnumControlRaw({
   data = [],
   placeholder = "Select a value",
+  allowNoOptions = false,
   required,
 }: Props) {
   const [value, setValue] = useControlState<FlatData>();
 
   const theme = useTheme();
 
-  const flattenedData = flatten(data);
+  const flattenedData = flatten(data, allowNoOptions);
 
   const handleSelectedItemChange = useCallback(
     ({ selectedItem }) => {
@@ -94,11 +104,11 @@ function NestedEnumControl({
   useEffect(() => {
     if (
       value !== undefined &&
-      !flatten(data).find((item) => item.value === value.value)
+      !flatten(data, allowNoOptions).find((item) => item.value === value.value)
     ) {
       setValue(undefined);
     }
-  }, [data, value, setValue]);
+  }, [data, allowNoOptions, value, setValue]);
 
   const {
     selectedItem,
@@ -144,4 +154,4 @@ function NestedEnumControl({
   );
 }
 
-export default createControl("NestedEnumControl", NestedEnumControl);
+export default createControl("NestedEnumControl", NestedEnumControlRaw);

--- a/packages/pipeline-editor/src/CustomFormControls/NestedEnumControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/NestedEnumControl.tsx
@@ -118,7 +118,6 @@ export function NestedEnumControl({
   }, [data, allowNoOptions, value, setValue]);
 
   const {
-    selectedItem,
     isOpen,
     getToggleButtonProps,
     getMenuProps,

--- a/packages/pipeline-editor/src/CustomFormControls/NumberControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/NumberControl.tsx
@@ -51,7 +51,7 @@ function deserialize(value: number | undefined) {
   return value?.toString();
 }
 
-function NumberControl({
+export function NumberControlRaw({
   type,
   multipleOf,
   minimum,
@@ -114,4 +114,4 @@ function NumberControl({
   );
 }
 
-export default createControl("NumberControl", NumberControl);
+export default createControl("NumberControl", NumberControlRaw);

--- a/packages/pipeline-editor/src/CustomFormControls/NumberControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/NumberControl.tsx
@@ -51,7 +51,7 @@ function deserialize(value: number | undefined) {
   return value?.toString();
 }
 
-export function NumberControlRaw({
+export function NumberControl({
   type,
   multipleOf,
   minimum,
@@ -114,4 +114,4 @@ export function NumberControlRaw({
   );
 }
 
-export default createControl("NumberControl", NumberControlRaw);
+export default createControl("NumberControl", NumberControl);

--- a/packages/pipeline-editor/src/CustomFormControls/OneOfControl.test.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/OneOfControl.test.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018-2021 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import OneOfControl from "./OneOfControl";
+
+it("has an id", () => {
+  expect(OneOfControl.id()).toBe("OneOfControl");
+});

--- a/packages/pipeline-editor/src/CustomFormControls/OneOfControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/OneOfControl.tsx
@@ -17,9 +17,9 @@
 import { useCallback } from "react";
 
 import { useSelect } from "downshift";
-import { useTheme } from "styled-components";
+import styled, { useTheme } from "styled-components";
 
-import { BooleanControlRaw } from "./BooleanControl";
+import { BooleanControl } from "./BooleanControl";
 import {
   EnumButton,
   EnumContainer,
@@ -29,52 +29,51 @@ import {
   EnumMenuItem,
 } from "./components";
 import { createControl, useControlState } from "./control";
-import { DisplayControlRaw } from "./DisplayControl";
-import { EnumControlRaw } from "./EnumControl";
-import { NestedEnumControlRaw } from "./NestedEnumControl";
-import { NumberControlRaw } from "./NumberControl";
-import { StringArrayControlRaw } from "./StringArrayControl";
-import { StringControlRaw } from "./StringControl";
+import { DisplayControl } from "./DisplayControl";
+import { EnumControl } from "./EnumControl";
+import { NestedEnumControl } from "./NestedEnumControl";
+import { NumberControl } from "./NumberControl";
+import { StringArrayControl } from "./StringArrayControl";
+import { StringControl } from "./StringControl";
 
 interface Props {
   controls: {
-    [k: string]: {
-      [j: string]: any;
+    [key: string]: {
+      [key: string]: any;
     };
   };
   required?: boolean;
 }
 
+export const ActiveControl = styled.div`
+  margin-top: 9px;
+`;
+
 function getControl(name: string, data: any) {
-  switch (name) {
-    case "StringControl":
-      return <StringControlRaw {...data} />;
-    case "DisplayControl":
-      return <DisplayControlRaw {...data} />;
-    case "StringArrayControl":
-      return <StringArrayControlRaw {...data} />;
-    case "BooleanControl":
-      return <BooleanControlRaw {...data} />;
-    case "EnumControl":
-      return <EnumControlRaw {...data} />;
-    case "NestedEnumControl":
-      return <NestedEnumControlRaw {...data} />;
-    case "NumberControl":
-      return <NumberControlRaw {...data} />;
-    default:
-      return null;
+  const controls: Record<string, any> = {
+    StringControl,
+    DisplayControl,
+    StringArrayControl,
+    BooleanControl,
+    EnumControl,
+    NestedEnumControl,
+    NumberControl,
+  };
+
+  const Control = controls[name];
+
+  if (Control) {
+    return <Control {...data} />;
   }
+  return null;
 }
 
-function OneOfControlRaw({ controls, required }: Props) {
-  const [
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    value,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    setValue,
-    activeControl,
-    setActiveControl,
-  ] = useControlState<string>(Object.keys(controls)[0]);
+function OneOfControl({ controls, required }: Props) {
+  const controlsKeys = Object.keys(controls);
+
+  const controlState = useControlState<string>(controlsKeys[0]);
+  const activeControl = controlState[2];
+  const setActiveControl = controlState[3];
 
   const theme = useTheme();
 
@@ -92,8 +91,8 @@ function OneOfControlRaw({ controls, required }: Props) {
     getMenuProps,
     getItemProps,
   } = useSelect({
-    items: Object.keys(controls),
-    selectedItem: activeControl || Object.keys(controls)[0],
+    items: controlsKeys,
+    selectedItem: activeControl || controlsKeys[0],
     onSelectedItemChange: handleSelectedItemChange,
   });
 
@@ -108,7 +107,7 @@ function OneOfControlRaw({ controls, required }: Props) {
         </EnumButton>
         <EnumMenu {...getMenuProps()}>
           {isOpen &&
-            Object.keys(controls).map((item, index) => (
+            controlsKeys.map((item, index) => (
               <EnumMenuItem
                 key={`${item}${index}`}
                 {...getItemProps({ item, index })}
@@ -120,11 +119,13 @@ function OneOfControlRaw({ controls, required }: Props) {
             ))}
         </EnumMenu>
       </EnumContainer>
-      {selectedItem
-        ? getControl(selectedItem, { ...controls[selectedItem], required })
-        : null}
+      <ActiveControl>
+        {selectedItem
+          ? getControl(selectedItem, { ...controls[selectedItem], required })
+          : null}
+      </ActiveControl>
     </div>
   );
 }
 
-export default createControl("OneOfControl", OneOfControlRaw);
+export default createControl("OneOfControl", OneOfControl);

--- a/packages/pipeline-editor/src/CustomFormControls/OneOfControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/OneOfControl.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018-2021 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback } from "react";
+
+import { useSelect } from "downshift";
+import { useTheme } from "styled-components";
+
+import { BooleanControlRaw } from "./BooleanControl";
+import {
+  EnumButton,
+  EnumContainer,
+  EnumIcon,
+  EnumLabel,
+  EnumMenu,
+  EnumMenuItem,
+} from "./components";
+import { createControl, useControlState } from "./control";
+import { DisplayControlRaw } from "./DisplayControl";
+import { EnumControlRaw } from "./EnumControl";
+import { NestedEnumControlRaw } from "./NestedEnumControl";
+import { NumberControlRaw } from "./NumberControl";
+import { StringArrayControlRaw } from "./StringArrayControl";
+import { StringControlRaw } from "./StringControl";
+
+interface Props {
+  controls: {
+    [k: string]: {
+      [j: string]: any;
+    };
+  };
+  required?: boolean;
+}
+
+function getControl(name: string, data: any) {
+  switch (name) {
+    case "StringControl":
+      return <StringControlRaw {...data} />;
+    case "DisplayControl":
+      return <DisplayControlRaw {...data} />;
+    case "StringArrayControl":
+      return <StringArrayControlRaw {...data} />;
+    case "BooleanControl":
+      return <BooleanControlRaw {...data} />;
+    case "EnumControl":
+      return <EnumControlRaw {...data} />;
+    case "NestedEnumControl":
+      return <NestedEnumControlRaw {...data} />;
+    case "NumberControl":
+      return <NumberControlRaw {...data} />;
+    default:
+      return null;
+  }
+}
+
+function OneOfControlRaw({ controls, required }: Props) {
+  const [
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    value,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    setValue,
+    activeControl,
+    setActiveControl,
+  ] = useControlState<string>(Object.keys(controls)[0]);
+
+  const theme = useTheme();
+
+  const handleSelectedItemChange = useCallback(
+    ({ selectedItem }) => {
+      setActiveControl(selectedItem);
+    },
+    [setActiveControl]
+  );
+
+  const {
+    selectedItem,
+    isOpen,
+    getToggleButtonProps,
+    getMenuProps,
+    getItemProps,
+  } = useSelect({
+    items: Object.keys(controls),
+    selectedItem: activeControl || Object.keys(controls)[0],
+    onSelectedItemChange: handleSelectedItemChange,
+  });
+
+  return (
+    <div>
+      <EnumContainer isOpen={isOpen}>
+        <EnumButton {...getToggleButtonProps()}>
+          <EnumLabel>{selectedItem}</EnumLabel>
+          <EnumIcon className="elyricon elyricon-chevron-down">
+            {theme.overrides?.chevronDownIcon}
+          </EnumIcon>
+        </EnumButton>
+        <EnumMenu {...getMenuProps()}>
+          {isOpen &&
+            Object.keys(controls).map((item, index) => (
+              <EnumMenuItem
+                key={`${item}${index}`}
+                {...getItemProps({ item, index })}
+              >
+                <EnumLabel title={controls[item].label ?? item}>
+                  {controls[item].label ?? item}
+                </EnumLabel>
+              </EnumMenuItem>
+            ))}
+        </EnumMenu>
+      </EnumContainer>
+      {selectedItem
+        ? getControl(selectedItem, { ...controls[selectedItem], required })
+        : null}
+    </div>
+  );
+}
+
+export default createControl("OneOfControl", OneOfControlRaw);

--- a/packages/pipeline-editor/src/CustomFormControls/OneOfControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/OneOfControl.tsx
@@ -71,7 +71,7 @@ function getControl(name: string, data: any) {
 function OneOfControl({ controls, required }: Props) {
   const controlsKeys = Object.keys(controls);
 
-  const controlState = useControlState<string>(controlsKeys[0]);
+  const controlState = useControlState<string>();
   const activeControl = controlState[2];
   const setActiveControl = controlState[3];
 

--- a/packages/pipeline-editor/src/CustomFormControls/OneOfControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/OneOfControl.tsx
@@ -101,11 +101,13 @@ function OneOfControl({ controls, required }: OneOfControlProps) {
     onSelectedItemChange: handleSelectedItemChange,
   });
 
+  const getLabel = (item: string | null) => controls[item ?? ""].label ?? item;
+
   return (
     <div>
       <EnumContainer isOpen={isOpen}>
         <EnumButton {...getToggleButtonProps()}>
-          <EnumLabel>{selectedItem}</EnumLabel>
+          <EnumLabel>{getLabel(selectedItem)}</EnumLabel>
           <EnumIcon className="elyricon elyricon-chevron-down">
             {theme.overrides?.chevronDownIcon}
           </EnumIcon>
@@ -117,9 +119,7 @@ function OneOfControl({ controls, required }: OneOfControlProps) {
                 key={`${item}${index}`}
                 {...getItemProps({ item, index })}
               >
-                <EnumLabel title={controls[item].label ?? item}>
-                  {controls[item].label ?? item}
-                </EnumLabel>
+                <EnumLabel title={getLabel(item)}>{getLabel(item)}</EnumLabel>
               </EnumMenuItem>
             ))}
         </EnumMenu>

--- a/packages/pipeline-editor/src/CustomFormControls/OneOfControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/OneOfControl.tsx
@@ -36,7 +36,12 @@ import { NumberControl } from "./NumberControl";
 import { StringArrayControl } from "./StringArrayControl";
 import { StringControl } from "./StringControl";
 
-interface Props {
+interface ActiveControlProps {
+  name: string;
+  data: any;
+}
+
+interface OneOfControlProps {
   controls: {
     [key: string]: {
       [key: string]: any;
@@ -45,11 +50,11 @@ interface Props {
   required?: boolean;
 }
 
-export const ActiveControl = styled.div`
+export const ActiveControlContainer = styled.div`
   margin-top: 9px;
 `;
 
-function getControl(name: string, data: any) {
+function ActiveControl({ name, data }: ActiveControlProps) {
   const controls: Record<string, any> = {
     StringControl,
     DisplayControl,
@@ -68,7 +73,7 @@ function getControl(name: string, data: any) {
   return null;
 }
 
-function OneOfControl({ controls, required }: Props) {
+function OneOfControl({ controls, required }: OneOfControlProps) {
   const controlsKeys = Object.keys(controls);
 
   const controlState = useControlState<string>();
@@ -92,7 +97,7 @@ function OneOfControl({ controls, required }: Props) {
     getItemProps,
   } = useSelect({
     items: controlsKeys,
-    selectedItem: activeControl || controlsKeys[0],
+    selectedItem: activeControl,
     onSelectedItemChange: handleSelectedItemChange,
   });
 
@@ -119,11 +124,14 @@ function OneOfControl({ controls, required }: Props) {
             ))}
         </EnumMenu>
       </EnumContainer>
-      <ActiveControl>
-        {selectedItem
-          ? getControl(selectedItem, { ...controls[selectedItem], required })
-          : null}
-      </ActiveControl>
+      <ActiveControlContainer>
+        {selectedItem ? (
+          <ActiveControl
+            name={selectedItem}
+            data={{ ...controls[selectedItem], required }}
+          />
+        ) : null}
+      </ActiveControlContainer>
     </div>
   );
 }

--- a/packages/pipeline-editor/src/CustomFormControls/StringArrayControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/StringArrayControl.tsx
@@ -288,11 +288,7 @@ export function ListItem({
   );
 }
 
-export function StringArrayControlRaw({
-  placeholder,
-  format,
-  canRefresh,
-}: Props) {
+export function StringArrayControl({ placeholder, format, canRefresh }: Props) {
   const propertyID = usePropertyID();
   const [items = [], setItems] = useControlState<string[]>();
 
@@ -421,4 +417,4 @@ export function StringArrayControlRaw({
   );
 }
 
-export default createControl("StringArrayControl", StringArrayControlRaw);
+export default createControl("StringArrayControl", StringArrayControl);

--- a/packages/pipeline-editor/src/CustomFormControls/StringArrayControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/StringArrayControl.tsx
@@ -288,7 +288,11 @@ export function ListItem({
   );
 }
 
-function StringArrayControl({ placeholder, format, canRefresh }: Props) {
+export function StringArrayControlRaw({
+  placeholder,
+  format,
+  canRefresh,
+}: Props) {
   const propertyID = usePropertyID();
   const [items = [], setItems] = useControlState<string[]>();
 
@@ -417,4 +421,4 @@ function StringArrayControl({ placeholder, format, canRefresh }: Props) {
   );
 }
 
-export default createControl("StringArrayControl", StringArrayControl);
+export default createControl("StringArrayControl", StringArrayControlRaw);

--- a/packages/pipeline-editor/src/CustomFormControls/StringControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/StringControl.tsx
@@ -55,7 +55,7 @@ function serialize(value: string) {
 }
 
 // TODO: Make the file clearable
-function StringControl({
+export function StringControlRaw({
   pattern,
   patternErrorMessage,
   minLength,
@@ -150,4 +150,4 @@ function StringControl({
   );
 }
 
-export default createControl("StringControl", StringControl);
+export default createControl("StringControl", StringControlRaw);

--- a/packages/pipeline-editor/src/CustomFormControls/StringControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/StringControl.tsx
@@ -55,7 +55,7 @@ function serialize(value: string) {
 }
 
 // TODO: Make the file clearable
-export function StringControlRaw({
+export function StringControl({
   pattern,
   patternErrorMessage,
   minLength,
@@ -150,4 +150,4 @@ export function StringControlRaw({
   );
 }
 
-export default createControl("StringControl", StringControlRaw);
+export default createControl("StringControl", StringControl);

--- a/packages/pipeline-editor/src/CustomFormControls/control/index.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/control/index.tsx
@@ -21,11 +21,13 @@ import { useSelector } from "react-redux";
 interface ContextValue {
   name: string;
   controller: any;
+  id: string;
 }
 
 const ControlContext = React.createContext<ContextValue>({
   name: "",
   controller: {},
+  id: "",
 });
 
 export function useHandlers() {
@@ -39,17 +41,51 @@ export function usePropertyID() {
   return name;
 }
 
-export function useControlState<T>() {
-  const { name, controller } = useContext(ControlContext);
+export function useControlState<T>(defaultControl?: T) {
+  const { name, controller, id } = useContext(ControlContext);
   const controllerRef = useRef(controller);
-  const value: T = useSelector((state: any) => state.propertiesReducer[name]);
+  const currentValue: any = useSelector((state: any) => {
+    return state.propertiesReducer[name];
+  });
+  const value: T = useSelector((state: any) => {
+    if (id !== "OneOfControl") {
+      return state.propertiesReducer[name];
+    } else {
+      const { activeControl } = state.propertiesReducer[name];
+      return state.propertiesReducer[name][activeControl];
+    }
+  });
+  const activeControl: string = useSelector((state: any) => {
+    return state.propertiesReducer[name]?.activeControl ?? defaultControl ?? "";
+  });
   const setValue = useCallback(
     (value: T) => {
-      controllerRef.current.updatePropertyValue({ name }, value);
+      if (id !== "OneOfControl") {
+        controllerRef.current.updatePropertyValue({ name }, value);
+      } else {
+        controllerRef.current.updatePropertyValue(
+          { name },
+          { ...currentValue, [activeControl]: value }
+        );
+      }
     },
-    [name]
+    [name, currentValue, activeControl, id]
   );
-  return [value, setValue] as [T | undefined, (value: T | undefined) => void];
+  const setActiveControl = useCallback(
+    (activeControl: string) => {
+      controllerRef.current.updatePropertyValue(
+        { name },
+        { ...currentValue, activeControl }
+      );
+    },
+    [name, currentValue]
+  );
+  return [value, setValue, activeControl, setActiveControl] as [
+    T | undefined,
+    (value: T | undefined) => void,
+    string,
+    (value: string) => void
+  ];
 }
 
 export function createControl(id: string, Component: any) {
@@ -59,7 +95,7 @@ export function createControl(id: string, Component: any) {
     controller: any,
     data: any
   ) {
-    this.value = { name: propertyId.name, controller };
+    this.value = { name: propertyId.name, controller, id };
     this.data = data;
   }
 

--- a/packages/pipeline-editor/src/CustomFormControls/control/index.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/control/index.tsx
@@ -50,10 +50,9 @@ export function useControlState<T>(defaultControl?: T) {
   const value: T = useSelector((state: any) => {
     if (id !== "OneOfControl") {
       return state.propertiesReducer[name];
-    } else {
-      const { activeControl } = state.propertiesReducer[name];
-      return state.propertiesReducer[name][activeControl];
     }
+    const { activeControl } = state.propertiesReducer[name];
+    return state.propertiesReducer[name][activeControl];
   });
   const activeControl: string = useSelector((state: any) => {
     return state.propertiesReducer[name]?.activeControl ?? defaultControl ?? "";

--- a/packages/pipeline-editor/src/CustomFormControls/control/index.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/control/index.tsx
@@ -41,7 +41,7 @@ export function usePropertyID() {
   return name;
 }
 
-export function useControlState<T>(defaultControl?: T) {
+export function useControlState<T>() {
   const { name, controller, id } = useContext(ControlContext);
   const controllerRef = useRef(controller);
   const currentValue: any = useSelector((state: any) => {
@@ -55,7 +55,7 @@ export function useControlState<T>(defaultControl?: T) {
     return state.propertiesReducer[name][activeControl];
   });
   const activeControl: string = useSelector((state: any) => {
-    return state.propertiesReducer[name]?.activeControl ?? defaultControl ?? "";
+    return state.propertiesReducer[name]?.activeControl ?? "";
   });
   const setValue = useCallback(
     (value: T) => {

--- a/packages/pipeline-editor/src/CustomFormControls/index.ts
+++ b/packages/pipeline-editor/src/CustomFormControls/index.ts
@@ -23,3 +23,4 @@ export { default as BooleanControl } from "./BooleanControl";
 export { default as EnumControl } from "./EnumControl";
 export { default as NestedEnumControl } from "./NestedEnumControl";
 export { default as NumberControl } from "./NumberControl";
+export { default as OneOfControl } from "./OneOfControl";

--- a/packages/pipeline-editor/src/CustomFormControls/validators/nested-enum-validators.ts
+++ b/packages/pipeline-editor/src/CustomFormControls/validators/nested-enum-validators.ts
@@ -19,11 +19,13 @@ import { Data, FlatData } from "../NestedEnumControl";
 
 export interface NestedEnumValidatorOptions {
   data: Data[];
+  allowNoOptions?: boolean;
   required?: boolean;
 }
 
 export function getNestedEnumValidators<T extends FlatData | undefined>({
   data,
+  allowNoOptions,
   required,
 }: NestedEnumValidatorOptions) {
   const validators: Validator<T>[] = [
@@ -38,7 +40,7 @@ export function getNestedEnumValidators<T extends FlatData | undefined>({
         const option = selected?.options?.find(
           (item: Data) => item.value === value?.option
         );
-        return !!(selected && option);
+        return !!selected && (allowNoOptions || !!option);
       },
       message: `Value must be a valid option`,
     },

--- a/packages/pipeline-editor/src/properties-panels/NodeProperties.tsx
+++ b/packages/pipeline-editor/src/properties-panels/NodeProperties.tsx
@@ -137,6 +137,17 @@ function NodeProperties({
             data,
             placeholder: "Select an input source",
           };
+        } else if (prop.data?.controls) {
+          for (const key in prop.data?.controls) {
+            if (prop.data?.controls[key].format === "inputpath") {
+              prop.data.controls[key] = {
+                ...prop.data.controls[key],
+                data,
+                allowNoOptions: true,
+                placeholder: "Select an input source",
+              };
+            }
+          }
         }
       }
     });


### PR DESCRIPTION
Adds a new OneOfControl that allows a property to have multiple types
and let a user choice which type they want to use then display the correct
form field.

This allows for support of properties that can either be entered directly or
taken from a parent node's output.

An example property using OneOfControl will look like the following inside `component_parameters`:

```
"slack_conn_id": {
    "activeControl": "StringControl",
    "NestedEnumControl": {
        "value": "Some parent node id",
        "option": ""
    },
    "StringControl": "Some string value"
}
```

Paired with https://github.com/elyra-ai/elyra/pull/2244

To Do's:
- [x] Add tests (stub added, more tests can be added in follow up)
- [x] Update validation (validation is being addressed server side, client side fixes will be done in follow up #171)
- [ ] Update version and migration (can be done in followup PR)
- [x] Tweak UI so it doesn't look terrible
- [x] Still needs updates on https://github.com/elyra-ai/elyra/pull/2244 to handle the OneOf property format

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

