### PR TITLE
Update var name to fix Airflow input dropdown

### DIFF
--- a/packages/pipeline-editor/src/CustomFormControls/NestedEnumControl.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/NestedEnumControl.tsx
@@ -47,11 +47,11 @@ export interface FlatData {
 interface Props {
   data?: Data[];
   placeholder?: string;
-  allowNoOptions?: boolean;
+  allownooptions?: boolean;
   required?: boolean;
 }
 
-function flatten(data: Data[], allowNoOptions: boolean): any[] {
+function flatten(data: Data[], allownooptions: boolean): any[] {
   let flattenedData: FlatData[] = [];
   data.forEach((item: Data) => {
     item.options?.forEach((option: Data) => {
@@ -60,7 +60,7 @@ function flatten(data: Data[], allowNoOptions: boolean): any[] {
         option: option.value,
       });
     });
-    if (allowNoOptions && (!item.options || item.options.length === 0)) {
+    if (allownooptions && (!item.options || item.options.length === 0)) {
       flattenedData.push({
         value: item.value,
         option: "",
@@ -88,14 +88,14 @@ function getLabel(
 export function NestedEnumControl({
   data = [],
   placeholder = "Select a value",
-  allowNoOptions = false,
+  allownooptions = false,
   required,
 }: Props) {
   const [value, setValue] = useControlState<FlatData>();
 
   const theme = useTheme();
 
-  const flattenedData = flatten(data, allowNoOptions);
+  const flattenedData = flatten(data, allownooptions);
 
   const handleSelectedItemChange = useCallback(
     ({ selectedItem }) => {
@@ -111,11 +111,11 @@ export function NestedEnumControl({
   useEffect(() => {
     if (
       value !== undefined &&
-      !flatten(data, allowNoOptions).find((item) => item.value === value.value)
+      !flatten(data, allownooptions).find((item) => item.value === value.value)
     ) {
       setValue(undefined);
     }
-  }, [data, allowNoOptions, value, setValue]);
+  }, [data, allownooptions, value, setValue]);
 
   const {
     isOpen,
@@ -130,7 +130,7 @@ export function NestedEnumControl({
 
   const validators = getNestedEnumValidators({
     data,
-    allowNoOptions,
+    allownooptions,
     required,
   });
 

--- a/packages/pipeline-editor/src/CustomFormControls/validators/nested-enum-validators.ts
+++ b/packages/pipeline-editor/src/CustomFormControls/validators/nested-enum-validators.ts
@@ -19,13 +19,13 @@ import { Data, FlatData } from "../NestedEnumControl";
 
 export interface NestedEnumValidatorOptions {
   data: Data[];
-  allowNoOptions?: boolean;
+  allownooptions?: boolean;
   required?: boolean;
 }
 
 export function getNestedEnumValidators<T extends FlatData | undefined>({
   data,
-  allowNoOptions,
+  allownooptions,
   required,
 }: NestedEnumValidatorOptions) {
   const validators: Validator<T>[] = [
@@ -40,7 +40,7 @@ export function getNestedEnumValidators<T extends FlatData | undefined>({
         const option = selected?.options?.find(
           (item: Data) => item.value === value?.option
         );
-        return !!selected && (allowNoOptions || !!option);
+        return !!selected && (allownooptions || !!option);
       },
       message: `Value must be a valid option`,
     },


### PR DESCRIPTION
The front end was looking for a var in camelCase when the back end
was passing it all lowercase. This caused Airflow properties to not
show thier parent nodes as options for input.

Fixes https://github.com/elyra-ai/elyra/issues/2413



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

