### PR TITLE
Add support for opening component definition

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -329,14 +329,15 @@ const PipelineEditor = forwardRef(
               return [
                 {
                   action: "openFile",
-                  label: "Open File",
+                  label: filenameRef
+                    ? "Open File"
+                    : "Open Component Definition",
                   // NOTE: This only checks if the string is empty, but we
                   // should verify the file exists.
-                  enable: !!(
-                    filenameRef !== undefined &&
-                    parameters?.[filenameRef] !== undefined &&
-                    parameters?.[filenameRef].trim() !== ""
-                  ),
+                  enable:
+                    filenameRef === undefined ||
+                    (parameters?.[filenameRef] !== undefined &&
+                      parameters?.[filenameRef].trim() !== ""),
                 },
                 {
                   action: "properties",
@@ -516,6 +517,7 @@ const PipelineEditor = forwardRef(
     const handleEditAction = useCallback(
       async (e: CanvasEditEvent) => {
         let payload;
+        let type = e.editType;
         if (e.editType === "openFile") {
           const filenameRef = controller.current.resolveParameterRef(
             e.targetObject.op,
@@ -524,9 +526,14 @@ const PipelineEditor = forwardRef(
           if (filenameRef) {
             payload =
               e.targetObject?.app_data?.component_parameters?.[filenameRef];
+          } else {
+            type = "openComponentDef";
+            payload = controller.current
+              .getAllPaletteNodes()
+              .find((n) => n.op === e.targetObject.op)?.id;
           }
         }
-        onAction?.({ type: e.editType, payload });
+        onAction?.({ type: type, payload });
 
         if (e.editType === "newFileNode") {
           const nodes = controller.current.getAllPaletteNodes();


### PR DESCRIPTION
Adds a new case for the `openFile` action that will instead trigger
the `openComponentDef` when a node has no defined `filenameRef`
(ie node's without a related file).

Handles the edge case when a `filenameRef` exists but the the
referenced property is not set the "Open File" option exists but
is disabled (as it was previously).

Elyra PR: https://github.com/elyra-ai/elyra/pull/2564
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

