### PR TITLE
Move validation to rjsf / ajv validator

### DIFF
--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -25,7 +25,7 @@
     "@elyra/pipeline-services": "^1.12.1",
     "@rjsf/core": "^5.0.0",
     "@rjsf/utils": "^5.0.0",
-    "@rjsf/validator-ajv6": "^5.0.0",
+    "@rjsf/validator-ajv8": "^5.0.0",
     "carbon-components": "^10.43.0",
     "carbon-components-react": "^7.48.0",
     "carbon-icons": "7.0.7",

--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -23,9 +23,9 @@
   "dependencies": {
     "@elyra/canvas": "^12.23.2",
     "@elyra/pipeline-services": "^1.12.1",
-    "@rjsf/core": "^5.0.0",
-    "@rjsf/utils": "^5.0.0",
-    "@rjsf/validator-ajv8": "^5.0.0",
+    "@rjsf/core": "~5.0.0",
+    "@rjsf/utils": "~5.0.0",
+    "@rjsf/validator-ajv8": "~5.0.0",
     "carbon-components": "^10.43.0",
     "carbon-components-react": "^7.48.0",
     "carbon-icons": "7.0.7",

--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -23,9 +23,9 @@
   "dependencies": {
     "@elyra/canvas": "^12.23.2",
     "@elyra/pipeline-services": "^1.12.1",
-    "@rjsf/core": "^5.0.0-beta.11",
-    "@rjsf/utils": "^5.0.0-beta.11",
-    "@rjsf/validator-ajv6": "^5.0.0-beta.11",
+    "@rjsf/core": "^5.0.0",
+    "@rjsf/utils": "^5.0.0",
+    "@rjsf/validator-ajv6": "^5.0.0",
     "carbon-components": "^10.43.0",
     "carbon-components-react": "^7.48.0",
     "carbon-icons": "7.0.7",

--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@elyra/canvas": "^12.23.2",
     "@elyra/pipeline-services": "^1.12.1",
-    "@rjsf/core": "^4.2.3",
+    "@rjsf/core": "^5.0.0-beta.2",
     "@rjsf/utils": "^5.0.0-beta.2",
     "@rjsf/validator-ajv6": "^5.0.0-beta.2",
     "carbon-components": "^10.43.0",

--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -23,9 +23,9 @@
   "dependencies": {
     "@elyra/canvas": "^12.23.2",
     "@elyra/pipeline-services": "^1.12.1",
-    "@rjsf/core": "^5.0.0-beta.2",
-    "@rjsf/utils": "^5.0.0-beta.2",
-    "@rjsf/validator-ajv6": "^5.0.0-beta.2",
+    "@rjsf/core": "^5.0.0-beta.11",
+    "@rjsf/utils": "^5.0.0-beta.11",
+    "@rjsf/validator-ajv6": "^5.0.0-beta.11",
     "carbon-components": "^10.43.0",
     "carbon-components-react": "^7.48.0",
     "carbon-icons": "7.0.7",

--- a/packages/pipeline-editor/src/CustomFormControls/CustomArray.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/CustomArray.tsx
@@ -16,7 +16,7 @@
 
 import { useCallback } from "react";
 
-import { ArrayFieldTemplateProps } from "@rjsf/utils";
+import { ArrayFieldTemplateProps, RJSFSchema } from "@rjsf/utils";
 
 const renderDefaults = (
   items: any[],
@@ -83,7 +83,7 @@ const renderDefaults = (
  * React component that allows for custom add / remove buttons in the array
  * field component.
  */
-export const ArrayTemplate: React.FC<ArrayFieldTemplateProps> = (props) => {
+export const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
   const renderedDefaults = renderDefaults(
     props.uiSchema?.pipeline_defaults ?? [],
     props

--- a/packages/pipeline-editor/src/CustomFormControls/CustomArray.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/CustomArray.tsx
@@ -16,7 +16,7 @@
 
 import { useCallback } from "react";
 
-import { ArrayFieldTemplateProps } from "@rjsf/core";
+import { ArrayFieldTemplateProps } from "@rjsf/utils";
 
 const renderDefaults = (
   items: any[],
@@ -85,13 +85,13 @@ const renderDefaults = (
  */
 export const ArrayTemplate: React.FC<ArrayFieldTemplateProps> = (props) => {
   const renderedDefaults = renderDefaults(
-    props.uiSchema.pipeline_defaults ?? [],
+    props.uiSchema?.pipeline_defaults ?? [],
     props
   );
   const handleChooseFile = useCallback(async () => {
     props.formContext.onFileRequested({
       canSelectMany: true,
-      filters: { File: props.uiSchema.extensions },
+      filters: { File: props.uiSchema?.extensions },
       propertyID: props.idSchema.$id.replace("root_component_parameters_", ""),
     });
   }, [props]);
@@ -120,7 +120,7 @@ export const ArrayTemplate: React.FC<ArrayFieldTemplateProps> = (props) => {
           {"Add"}
         </button>
       )}
-      {props.uiSchema.canRefresh && (
+      {props.uiSchema?.canRefresh && (
         <button
           className="jp-mod-styled jp-mod-reject"
           style={{ marginLeft: "5px" }}

--- a/packages/pipeline-editor/src/CustomFormControls/CustomFieldTemplate.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/CustomFieldTemplate.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { FieldTemplateProps } from "@rjsf/core";
+import { FieldTemplateProps } from "@rjsf/utils";
 
 export const CustomFieldTemplate: React.FC<FieldTemplateProps> = (props) => {
   let children = props.children;
-  if (props.uiSchema["ui:field"] === "hidden") {
+  if (props.uiSchema?.["ui:field"] === "hidden") {
     return <div />;
   }
-  if (props.uiSchema["ui:readonly"]) {
+  if (props.uiSchema?.["ui:readonly"]) {
     children = (
       <div style={{ paddingTop: "8px" }}>
         {props.formData ?? props.schema.default}
@@ -60,7 +60,7 @@ export const CustomFieldTemplate: React.FC<FieldTemplateProps> = (props) => {
       {props.schema.title !== undefined && props.schema.title !== " " ? (
         <div
           className={`label-header ${
-            props.uiSchema["ui:field"] === "header" ? "category-header" : ""
+            props.uiSchema?.["ui:field"] === "header" ? "category-header" : ""
           }`}
         >
           <label className="control-label" htmlFor={props.id}>

--- a/packages/pipeline-editor/src/CustomFormControls/CustomFieldTemplate.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/CustomFieldTemplate.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import { FieldTemplateProps } from "@rjsf/utils";
+import { FieldTemplateProps, RJSFSchema } from "@rjsf/utils";
 
-export const CustomFieldTemplate: React.FC<FieldTemplateProps> = (props) => {
+export const FieldTemplate: React.ComponentType<
+  FieldTemplateProps<any, RJSFSchema, any>
+> = (props) => {
   let children = props.children;
   if (props.uiSchema?.["ui:field"] === "hidden") {
     return <div />;

--- a/packages/pipeline-editor/src/CustomFormControls/CustomFieldTemplate.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/CustomFieldTemplate.tsx
@@ -82,7 +82,6 @@ export const CustomFieldTemplate: React.FC<FieldTemplateProps> = (props) => {
       ) : undefined}
       {children}
       {props.errors}
-      {requiredError && <li className="text-danger">is a required property</li>}
     </div>
   );
 };

--- a/packages/pipeline-editor/src/CustomFormControls/CustomFieldTemplate.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/CustomFieldTemplate.tsx
@@ -46,7 +46,9 @@ export const CustomFieldTemplate: React.FC<FieldTemplateProps> = (props) => {
     }
   }
   const requiredError = props.required && props.formData === undefined;
-  const hasError = props.rawErrors?.length !== 0 || requiredError;
+  const hasError =
+    (props.rawErrors !== undefined && props.rawErrors.length !== 0) ||
+    requiredError;
   return (
     <div
       className={`${props.classNames} ${

--- a/packages/pipeline-editor/src/CustomFormControls/CustomFieldTemplate.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/CustomFieldTemplate.tsx
@@ -46,7 +46,7 @@ export const CustomFieldTemplate: React.FC<FieldTemplateProps> = (props) => {
     }
   }
   const requiredError = props.required && props.formData === undefined;
-  const hasError = props.rawErrors || requiredError;
+  const hasError = props.rawErrors?.length !== 0 || requiredError;
   return (
     <div
       className={`${props.classNames} ${

--- a/packages/pipeline-editor/src/CustomFormControls/CustomOneOf.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/CustomOneOf.tsx
@@ -20,8 +20,9 @@ import {
   getDefaultFormState,
   getUiOptions,
   getWidget,
+  RJSFSchema,
 } from "@rjsf/utils";
-import validator from "@rjsf/validator-ajv6";
+import validator from "@rjsf/validator-ajv8";
 
 /**
  * A custom oneOf field to handle the 2 custom oneOf cases that Elyra has:
@@ -31,7 +32,7 @@ import validator from "@rjsf/validator-ajv6";
  * 2. "inputpath": Each oneOf entry represents a different set object
  *       Selecting the options based on the default values of the given oneOf object.
  */
-export const CustomOneOf: Field = (props) => {
+export const OneOfField: Field<any, RJSFSchema, any> = (props) => {
   const { options, formData, registry } = props;
   const findOption = (): any => {
     // For inputpaths, expect a oneOf that has { value, option } for each entry

--- a/packages/pipeline-editor/src/CustomFormControls/CustomOneOf.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/CustomOneOf.tsx
@@ -48,7 +48,7 @@ export const CustomOneOf: Field = (props) => {
       return 0;
     }
     // for other oneOfs, check for widget specified in the "value" uihints to match the saved widget
-    for (const i in options as any[]) {
+    for (let i = 0; i < options.length; i++) {
       const option = options[i];
       if (
         (formData?.widget &&

--- a/packages/pipeline-editor/src/CustomFormControls/CustomOneOf.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/CustomOneOf.tsx
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import { Field, FieldProps, utils, WidgetProps } from "@rjsf/core";
+import {
+  Field,
+  FieldProps,
+  WidgetProps,
+  getDefaultFormState,
+  getUiOptions,
+  getWidget,
+} from "@rjsf/utils";
 
 /**
  * A custom oneOf field to handle the 2 custom oneOf cases that Elyra has:
@@ -60,23 +67,15 @@ export const CustomOneOf: Field = (props) => {
     // Call getDefaultFormState to make sure defaults are populated on change.
     let defaults;
     try {
-      defaults = utils.getDefaultFormState(
-        options[selectedOption],
-        undefined,
-        rootSchema
-      );
+      defaults = getDefaultFormState(options[selectedOption], {}, rootSchema);
     } catch {}
     props.onChange(defaults);
   };
 
   const SchemaField = registry.fields.SchemaField as React.FC<FieldProps>;
   const { widgets } = registry;
-  const uiOptions = (utils.getUiOptions(props.uiSchema) ?? {}) as WidgetProps;
-  const Widget = utils.getWidget(
-    { type: "number" },
-    "select",
-    widgets
-  ) as React.FC<WidgetProps>;
+  const uiOptions = getUiOptions(props.uiSchema ?? {});
+  const Widget = getWidget({ type: "number" }, "select", widgets);
 
   const option = options[findOption()] || null;
   let optionSchema;
@@ -109,7 +108,8 @@ export const CustomOneOf: Field = (props) => {
     <div className="panel panel-default panel-body">
       <div className="form-group">
         <Widget
-          {...uiOptions}
+          uiSchema={uiOptions}
+          label={""}
           id={`${props.idSchema.$id}${
             props.schema.oneOf ? "__oneof_select" : "__anyof_select"
           }`}

--- a/packages/pipeline-editor/src/CustomFormControls/CustomOneOf.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/CustomOneOf.tsx
@@ -17,11 +17,11 @@
 import {
   Field,
   FieldProps,
-  WidgetProps,
   getDefaultFormState,
   getUiOptions,
   getWidget,
 } from "@rjsf/utils";
+import validator from "@rjsf/validator-ajv6";
 
 /**
  * A custom oneOf field to handle the 2 custom oneOf cases that Elyra has:
@@ -67,7 +67,12 @@ export const CustomOneOf: Field = (props) => {
     // Call getDefaultFormState to make sure defaults are populated on change.
     let defaults;
     try {
-      defaults = getDefaultFormState(options[selectedOption], {}, rootSchema);
+      defaults = getDefaultFormState(
+        validator,
+        options[selectedOption],
+        {},
+        rootSchema
+      );
     } catch {}
     props.onChange(defaults);
   };
@@ -128,6 +133,7 @@ export const CustomOneOf: Field = (props) => {
           {...props}
           schema={optionSchema}
           uiSchema={optionSchema.uihints}
+          errorSchema={props.errorSchema?.["value"]}
         />
       )}
     </div>

--- a/packages/pipeline-editor/src/CustomFormControls/FileWidget.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/FileWidget.tsx
@@ -16,10 +16,12 @@
 
 import { useCallback } from "react";
 
-import { Widget, WidgetProps } from "@rjsf/utils";
+import { RJSFSchema, Widget, WidgetProps } from "@rjsf/utils";
 
 // TODO: Make the file clearable
-export const FileWidget: Widget = (props: WidgetProps) => {
+export const FileWidget: Widget<any, RJSFSchema, any> = (
+  props: WidgetProps
+) => {
   const handleChooseFile = useCallback(async () => {
     props.formContext.onFileRequested({
       canSelectMany: false,

--- a/packages/pipeline-editor/src/CustomFormControls/FileWidget.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/FileWidget.tsx
@@ -16,7 +16,7 @@
 
 import { useCallback } from "react";
 
-import { Widget } from "@rjsf/core";
+import { Widget } from "@rjsf/utils";
 
 // TODO: Make the file clearable
 export const FileWidget: Widget = (props) => {
@@ -24,7 +24,7 @@ export const FileWidget: Widget = (props) => {
     props.formContext.onFileRequested({
       canSelectMany: false,
       defaultUri: props.value,
-      filters: { File: props.uiSchema.extensions },
+      filters: { File: props.uiSchema?.extensions },
       propertyID: props.id.replace("root_component_parameters_", ""),
       parentID: props.uiSchema?.parentID,
     });

--- a/packages/pipeline-editor/src/CustomFormControls/FileWidget.tsx
+++ b/packages/pipeline-editor/src/CustomFormControls/FileWidget.tsx
@@ -16,10 +16,10 @@
 
 import { useCallback } from "react";
 
-import { Widget } from "@rjsf/utils";
+import { Widget, WidgetProps } from "@rjsf/utils";
 
 // TODO: Make the file clearable
-export const FileWidget: Widget = (props) => {
+export const FileWidget: Widget = (props: WidgetProps) => {
   const handleChooseFile = useCallback(async () => {
     props.formContext.onFileRequested({
       canSelectMany: false,

--- a/packages/pipeline-editor/src/PipelineController/index.test.ts
+++ b/packages/pipeline-editor/src/PipelineController/index.test.ts
@@ -275,7 +275,6 @@ describe("addNode", () => {
       component_parameters: {
         stringExample: "is-set",
         emptyArrayExample: [],
-        emptyObjectExample: {},
         trueExample: true,
         falseExample: false,
         nullExample: null,
@@ -313,7 +312,6 @@ describe("addNode", () => {
         filename: "fake.py",
         stringExample: "is-set",
         emptyArrayExample: ["one", "two", "three"],
-        emptyObjectExample: {},
         trueExample: true,
         falseExample: false,
         nullExample: null,

--- a/packages/pipeline-editor/src/PipelineController/index.ts
+++ b/packages/pipeline-editor/src/PipelineController/index.ts
@@ -23,7 +23,7 @@ import {
 } from "@elyra/canvas";
 import { validate } from "@elyra/pipeline-services";
 import { getDefaultFormState } from "@rjsf/utils";
-import validator from "@rjsf/validator-ajv6";
+import validator from "@rjsf/validator-ajv8";
 import produce from "immer";
 
 import {

--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -755,6 +755,7 @@ const PipelineEditor = forwardRef(
             onFileRequested={onFileRequested}
             onPropertiesUpdateRequested={onPropertiesUpdateRequested}
             onChange={handlePipelineParametersChange}
+            noValidate={true}
             id="pipeline-parameters"
           />
         ),

--- a/packages/pipeline-editor/src/properties-panels/PropertiesPanel.tsx
+++ b/packages/pipeline-editor/src/properties-panels/PropertiesPanel.tsx
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
-import Form, { UiSchema, Widget, AjvError } from "@rjsf/core";
 import { produce } from "immer";
+import Form from "@rjsf/core";
+import { UiSchema, Widget } from "@rjsf/utils";
+import {
+  transformErrors,
+  createCustomValidator,
+} from "@elyra/pipeline-services";
+import validator from "@rjsf/validator-ajv6";
 import styled from "styled-components";
 
 import {
@@ -88,6 +94,7 @@ export function PropertiesPanel({
       formData={data}
       uiSchema={uiSchema}
       schema={schema as any}
+      customValidate={createCustomValidator(schema)}
       onChange={(e) => {
         const newFormData = e.formData;
         const params = schema.properties?.component_parameters?.properties;
@@ -137,25 +144,14 @@ export function PropertiesPanel({
         OneOfField: CustomOneOf,
       }}
       liveValidate={!noValidate}
-      ArrayFieldTemplate={ArrayTemplate}
-      noHtml5Validate
-      FieldTemplate={CustomFieldTemplate}
-      className={"elyra-formEditor"}
-      transformErrors={(errors: AjvError[]) => {
-        // Suppress the "oneof" validation because we're using oneOf in a custom way.
-        const transformed = [];
-        for (const error of errors) {
-          if (
-            error.message !== "should match exactly one schema in oneOf" &&
-            !(error as any).schemaPath?.includes("oneOf") &&
-            error.message !== "should be object" &&
-            error.message !== "should be string"
-          ) {
-            transformed.push(error);
-          }
-        }
-        return transformed;
+      validator={validator}
+      templates={{
+        ArrayFieldTemplate: ArrayTemplate,
+        FieldTemplate: CustomFieldTemplate,
       }}
+      noHtml5Validate
+      className={"elyra-formEditor"}
+      transformErrors={transformErrors}
     />
   );
 }

--- a/packages/pipeline-editor/src/properties-panels/PropertiesPanel.tsx
+++ b/packages/pipeline-editor/src/properties-panels/PropertiesPanel.tsx
@@ -15,12 +15,12 @@
  */
 
 import { produce } from "immer";
-import Form from "@rjsf/core";
-import { UiSchema, Widget } from "@rjsf/utils";
 import {
   transformErrors,
   createCustomValidator,
 } from "@elyra/pipeline-services";
+import Form from "@rjsf/core";
+import { UiSchema, Widget } from "@rjsf/utils";
 import validator from "@rjsf/validator-ajv6";
 import styled from "styled-components";
 

--- a/packages/pipeline-editor/src/properties-panels/PropertiesPanel.tsx
+++ b/packages/pipeline-editor/src/properties-panels/PropertiesPanel.tsx
@@ -96,18 +96,6 @@ export function PropertiesPanel({
       schema={schema as any}
       customValidate={createCustomValidator(schema)}
       onChange={(e) => {
-        const newFormData = e.formData;
-        const params = schema.properties?.component_parameters?.properties;
-        for (const field in params) {
-          if (params[field].oneOf) {
-            for (const option of params[field].oneOf) {
-              if (option.widget?.const !== undefined) {
-                newFormData.component_parameters[field].widget =
-                  option.widget.const;
-              }
-            }
-          }
-        }
         onChange?.(e.formData);
       }}
       formContext={{

--- a/packages/pipeline-editor/src/properties-panels/PropertiesPanel.tsx
+++ b/packages/pipeline-editor/src/properties-panels/PropertiesPanel.tsx
@@ -19,7 +19,7 @@ import {
   createCustomValidator,
 } from "@elyra/pipeline-services";
 import Form from "@rjsf/core";
-import { UiSchema, Widget } from "@rjsf/utils";
+import { UiSchema, RegistryWidgetsType } from "@rjsf/utils";
 import validator from "@rjsf/validator-ajv6";
 import { produce } from "immer";
 import styled from "styled-components";
@@ -40,10 +40,6 @@ export const Message = styled.div`
   color: ${({ theme }) => theme.palette.text.primary};
   opacity: 0.5;
 `;
-
-const widgets: { [id: string]: Widget } = {
-  file: FileWidget,
-};
 
 interface Props {
   data: any;
@@ -68,7 +64,7 @@ export function PropertiesPanel({
     return <Message>No properties defined.</Message>;
   }
 
-  let uiSchema: UiSchema = {};
+  let uiSchema: any = {};
   for (const field in schema.properties) {
     uiSchema[field] = {};
     const properties = schema.properties[field];
@@ -99,7 +95,7 @@ export function PropertiesPanel({
         onChange?.(e.formData);
       }}
       formContext={{
-        onFileRequested: async (args: any, fieldName: string) => {
+        onFileRequested: async (args: any) => {
           const values = await onFileRequested?.({
             ...args,
             filename: data.component_parameters.filename,
@@ -127,7 +123,9 @@ export function PropertiesPanel({
         formData: data,
       }}
       id={id}
-      widgets={widgets}
+      widgets={{
+        file: FileWidget,
+      }}
       fields={{
         OneOfField: CustomOneOf,
       }}

--- a/packages/pipeline-editor/src/properties-panels/PropertiesPanel.tsx
+++ b/packages/pipeline-editor/src/properties-panels/PropertiesPanel.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { produce } from "immer";
 import {
   transformErrors,
   createCustomValidator,
@@ -22,6 +21,7 @@ import {
 import Form from "@rjsf/core";
 import { UiSchema, Widget } from "@rjsf/utils";
 import validator from "@rjsf/validator-ajv6";
+import { produce } from "immer";
 import styled from "styled-components";
 
 import {

--- a/packages/pipeline-editor/src/properties-panels/PropertiesPanel.tsx
+++ b/packages/pipeline-editor/src/properties-panels/PropertiesPanel.tsx
@@ -19,7 +19,6 @@ import {
   createCustomValidator,
 } from "@elyra/pipeline-services";
 import Form from "@rjsf/core";
-import { UiSchema, RegistryWidgetsType } from "@rjsf/utils";
 import validator from "@rjsf/validator-ajv6";
 import { produce } from "immer";
 import styled from "styled-components";

--- a/packages/pipeline-editor/src/properties-panels/PropertiesPanel.tsx
+++ b/packages/pipeline-editor/src/properties-panels/PropertiesPanel.tsx
@@ -14,20 +14,18 @@
  * limitations under the License.
  */
 
-import {
-  transformErrors,
-  createCustomValidator,
-} from "@elyra/pipeline-services";
+import { transformErrors } from "@elyra/pipeline-services";
 import Form from "@rjsf/core";
-import validator from "@rjsf/validator-ajv6";
+import { RegistryFieldsType, RegistryWidgetsType } from "@rjsf/utils";
+import validator from "@rjsf/validator-ajv8";
 import { produce } from "immer";
 import styled from "styled-components";
 
 import {
   FileWidget,
-  CustomFieldTemplate,
-  ArrayTemplate,
-  CustomOneOf,
+  FieldTemplate,
+  ArrayFieldTemplate,
+  OneOfField,
 } from "../CustomFormControls";
 
 export const Message = styled.div`
@@ -49,6 +47,14 @@ interface Props {
   noValidate?: boolean;
   id?: string;
 }
+
+const widgets: RegistryWidgetsType = {
+  FileWidget,
+};
+
+const fields: RegistryFieldsType = {
+  OneOfField,
+};
 
 export function PropertiesPanel({
   data,
@@ -89,7 +95,6 @@ export function PropertiesPanel({
       formData={data}
       uiSchema={uiSchema}
       schema={schema as any}
-      customValidate={createCustomValidator(schema)}
       onChange={(e) => {
         onChange?.(e.formData);
       }}
@@ -122,17 +127,13 @@ export function PropertiesPanel({
         formData: data,
       }}
       id={id}
-      widgets={{
-        file: FileWidget,
-      }}
-      fields={{
-        OneOfField: CustomOneOf,
-      }}
+      widgets={widgets}
+      fields={fields}
       liveValidate={!noValidate}
       validator={validator}
       templates={{
-        ArrayFieldTemplate: ArrayTemplate,
-        FieldTemplate: CustomFieldTemplate,
+        ArrayFieldTemplate,
+        FieldTemplate,
       }}
       noHtml5Validate
       className={"elyra-formEditor"}

--- a/packages/pipeline-editor/src/test-utils.tsx
+++ b/packages/pipeline-editor/src/test-utils.tsx
@@ -82,6 +82,8 @@ export const samplePalette = {
                     },
                     emptyObjectExample: {
                       type: "object",
+                      properties: {},
+                      default: {},
                     },
                     falseExample: {
                       type: "boolean",
@@ -159,14 +161,8 @@ export const nodeSpec: CustomNodeSpecification = {
           runtime_image: {
             title: "Runtime Image",
             type: "string",
-            enum: ["runtime1, runtime2"],
+            enum: ["runtime1", "runtime2"],
             description: "Docker image used as execution environment.",
-            uihints: {
-              items: [
-                "continuumio/anaconda3:2020.07",
-                "amancevice/pandas:1.0.3",
-              ],
-            },
           },
           dependencies: {
             title: "File Dependencies",
@@ -219,7 +215,7 @@ export const selectedNode = {
     label: "",
     component_parameters: {
       filename: "example.ipynb",
-      runtime_image: "example/runtime:2020.07",
+      runtime_image: "runtime1",
       env_vars: [],
       include_subdirectories: false,
       outputs: ["file1.csv", "file2.zip"],
@@ -321,7 +317,7 @@ export const samplePipeline = {
             label: "",
             component_parameters: {
               filename: "goodbye.ipynb",
-              runtime_image: "continuumio/anaconda3:2020.07",
+              runtime_image: "runtime2",
               dependencies: [],
               include_subdirectories: false,
               env_vars: ["bloop"],

--- a/packages/pipeline-services/package.json
+++ b/packages/pipeline-services/package.json
@@ -22,6 +22,8 @@
     "link": "yarn link"
   },
   "dependencies": {
+    "@rjsf/utils": "^5.0.0-beta.11",
+    "@rjsf/validator-ajv6": "^5.0.0-beta.11",
     "immer": "^9.0.7",
     "jsonc-parser": "^3.0.0"
   },

--- a/packages/pipeline-services/package.json
+++ b/packages/pipeline-services/package.json
@@ -22,8 +22,8 @@
     "link": "yarn link"
   },
   "dependencies": {
-    "@rjsf/utils": "^5.0.0",
-    "@rjsf/validator-ajv8": "^5.0.0",
+    "@rjsf/utils": "~5.0.0",
+    "@rjsf/validator-ajv8": "~5.0.0",
     "immer": "^9.0.7",
     "jsonc-parser": "^3.0.0"
   },

--- a/packages/pipeline-services/package.json
+++ b/packages/pipeline-services/package.json
@@ -22,8 +22,8 @@
     "link": "yarn link"
   },
   "dependencies": {
-    "@rjsf/utils": "^5.0.0-beta.11",
-    "@rjsf/validator-ajv6": "^5.0.0-beta.11",
+    "@rjsf/utils": "^5.0.0",
+    "@rjsf/validator-ajv8": "^5.0.0",
     "immer": "^9.0.7",
     "jsonc-parser": "^3.0.0"
   },

--- a/packages/pipeline-services/src/validation/index.test.ts
+++ b/packages/pipeline-services/src/validation/index.test.ts
@@ -147,52 +147,6 @@ describe("getNodeProblems", () => {
     expect(problems[0].info.property).toBe("filename");
   });
 
-  it("should have issues when required property has a default value and is empty", () => {
-    const nodeSpec = {
-      op: "execute-notebook-node",
-      app_data: {
-        properties: {
-          type: "object",
-          properties: {
-            component_parameters: {
-              type: "object",
-              properties: {
-                has_default: {
-                  title: "Example",
-                  description: "this is an example.",
-                  type: "string",
-                  default: "default",
-                },
-              },
-              required: ["has_default"],
-            },
-          },
-          required: ["component_parameters"],
-        },
-      },
-    };
-
-    const pipeline = {
-      nodes: [
-        {
-          id: "node-1",
-          type: "execution_node",
-          op: "execute-notebook-node",
-          app_data: {
-            ui_data: {
-              label: "Node 1",
-            },
-          },
-        },
-      ],
-    };
-
-    const problems = getNodeProblems(pipeline, [nodeSpec]) as any;
-    expect(problems).toHaveLength(1);
-    expect(problems[0].info.type).toBe("missingProperty");
-    expect(problems[0].info.property).toBe("has_default");
-  });
-
   it("should find missing properties for empty strings", () => {
     const pipeline = {
       nodes: [
@@ -214,9 +168,11 @@ describe("getNodeProblems", () => {
     };
 
     const problems = getNodeProblems(pipeline, [nodeSpec]) as any;
-    expect(problems).toHaveLength(1);
+    expect(problems).toHaveLength(2);
     expect(problems[0].info.type).toBe("missingProperty");
-    expect(problems[0].info.property).toBe("filename");
+    expect(problems[0].info.property).toBe("runtime_image");
+    expect(problems[1].info.type).toBe("missingProperty");
+    expect(problems[1].info.property).toBe("filename");
   });
 
   it("should return no problems if required properties are provided", () => {
@@ -229,7 +185,7 @@ describe("getNodeProblems", () => {
           app_data: {
             component_parameters: {
               filename: "example.py",
-              runtime_image: "example/runtime:1.2.3",
+              runtime_image: "amancevice/pandas:1.4.1",
             },
             ui_data: {
               label: "Node 1",

--- a/packages/pipeline-services/src/validation/index.ts
+++ b/packages/pipeline-services/src/validation/index.ts
@@ -124,8 +124,15 @@ export function getPipelineProblems(pipeline: any, pipelineProperties: any) {
 }
 
 function getPropertyName(property: string) {
-  console.log(property);
-  return property.split(/[[''\]]+/)[1]?.replace("'", "");
+  // Split out the name without brackets for more complicated property names.
+  // Ex: properties['runtime_image'].items -> you would only want runtime_image
+  const propertyWithoutBrackets = property.split(/[[''\]]+/);
+  if (propertyWithoutBrackets.length === 1) {
+    // Properties that don't have brackets will start with '.', so remove that as well.
+    return propertyWithoutBrackets[0].replace(".", "");
+  } else {
+    return property.split(/[[''\]]+/)[1]?.replace("'", "");
+  }
 }
 
 export function getNodeProblems(pipeline: any, nodeDefinitions: any) {

--- a/packages/pipeline-services/src/validation/index.ts
+++ b/packages/pipeline-services/src/validation/index.ts
@@ -125,7 +125,7 @@ export function getPipelineProblems(pipeline: any, pipelineProperties: any) {
 
 function getPropertyName(property: string) {
   console.log(property);
-  return property.split(/[\[''\]]+/)[1]?.replace("'", "");
+  return property.split(/[[''\]]+/)[1]?.replace("'", "");
 }
 
 export function getNodeProblems(pipeline: any, nodeDefinitions: any) {

--- a/packages/pipeline-services/src/validation/index.ts
+++ b/packages/pipeline-services/src/validation/index.ts
@@ -47,13 +47,23 @@ export function createCustomValidator(schema: any): CustomValidator {
       ) {
         errors[field]?.addError("required field");
       }
+      if (schema.required?.includes(field) && formData[field] === "") {
+        errors[field]?.addError("required field");
+      }
     }
+    const component_parameters = schema.properties?.component_parameters ?? {};
     for (const field in formData.component_parameters ?? {}) {
       if (
-        schema.properties?.component_parameters?.required?.includes(field) &&
+        component_parameters.required?.includes(field) &&
         formData.component_parameters[field]?.widget &&
         (formData.component_parameters[field]?.value === undefined ||
           formData.component_parameters[field]?.value === "")
+      ) {
+        errors["component_parameters"]?.[field]?.addError("required field");
+      }
+      if (
+        component_parameters.required?.includes(field) &&
+        formData.component_parameters?.[field] === ""
       ) {
         errors["component_parameters"]?.[field]?.addError("required field");
       }
@@ -149,7 +159,11 @@ export function getNodeProblems(pipeline: any, nodeDefinitions: any) {
       transformErrors
     ).errors;
     for (const error of errorMessages) {
-      const property = error.property?.replace(".", "") ?? "";
+      const property =
+        error.property
+          ?.replace(".properties['", "")
+          ?.replace("'].required", "")
+          ?.replace(".", "") ?? "";
       problems.push({
         message: error.message ?? "",
         path: error.params,

--- a/packages/pipeline-services/src/validation/index.ts
+++ b/packages/pipeline-services/src/validation/index.ts
@@ -168,6 +168,9 @@ export function getNodeProblems(pipeline: any, nodeDefinitions: any) {
       transformErrors
     ).errors;
     for (const error of errorMessages) {
+      if (error.stack.includes("schema is invalid")) {
+        continue;
+      }
       const property = getPropertyName(error.property ?? "");
       problems.push({
         message: error.message ?? "",

--- a/packages/pipeline-services/src/validation/index.ts
+++ b/packages/pipeline-services/src/validation/index.ts
@@ -32,7 +32,12 @@ import { ErrorTransformer, CustomValidator, FormValidation } from "@rjsf/utils";
 export const transformErrors: ErrorTransformer = (errors) => {
   const newErrors = [];
   for (const error of errors ?? []) {
-    if (error.name !== "minItems") {
+    if (
+      error.name !== "minItems" &&
+      error.name !== "oneOf" &&
+      error.message !== "should be object" &&
+      error.message !== "should be string"
+    ) {
       newErrors.push(error);
     }
   }
@@ -40,7 +45,7 @@ export const transformErrors: ErrorTransformer = (errors) => {
 };
 
 export function createCustomValidator(schema: any): CustomValidator {
-  return (formData: any, errors: FormValidation) => {
+  const validate = (formData: any, errors: FormValidation) => {
     for (const field in formData) {
       if (
         schema.required?.includes(field) &&
@@ -50,8 +55,19 @@ export function createCustomValidator(schema: any): CustomValidator {
         errors[field]?.addError("required field");
       }
     }
+    for (const field in formData.component_parameters ?? {}) {
+      if (
+        schema.properties?.component_parameters?.required?.includes(field) &&
+        formData.component_parameters[field]?.widget &&
+        (formData.component_parameters[field]?.value === undefined ||
+          formData.component_parameters[field]?.value === "")
+      ) {
+        errors["component_parameters"]?.[field]?.addError("required field");
+      }
+    }
     return errors;
   };
+  return validate;
 }
 
 export function getLinkProblems(pipeline: any) {

--- a/packages/pipeline-services/src/validation/index.ts
+++ b/packages/pipeline-services/src/validation/index.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import { ErrorTransformer, CustomValidator, FormValidation } from "@rjsf/utils";
-import validator from "@rjsf/validator-ajv6";
+import { CustomValidator, FormValidation } from "@rjsf/utils";
+import validator from "@rjsf/validator-ajv8";
 import { parseTree, findNodeAtLocation } from "jsonc-parser";
 
 import checkCircularReferences from "./check-circular-references";
 import { PartialProblem, Problem } from "./types";
 import { findNode, getLinks, getNodes, rangeForLocation } from "./utils";
 
-export const transformErrors: ErrorTransformer = (errors) => {
+export const transformErrors = (errors: any[]): any[] => {
   const newErrors = [];
   for (const error of errors ?? []) {
     if (

--- a/packages/pipeline-services/src/validation/index.ts
+++ b/packages/pipeline-services/src/validation/index.ts
@@ -114,16 +114,18 @@ export function getPipelineProblems(pipeline: any, pipelineProperties: any) {
       path: error.params,
       info: {
         pipelineID: pipeline.id,
-        property:
-          error.property
-            ?.replace(".properties['", "")
-            ?.replace("'].required", "") ?? "",
+        property: getPropertyName(error.property ?? ""),
         type: "missingProperty",
       },
     });
   }
 
   return problems;
+}
+
+function getPropertyName(property: string) {
+  console.log(property);
+  return property.split(/[\[''\]]+/)[1]?.replace("'", "");
 }
 
 export function getNodeProblems(pipeline: any, nodeDefinitions: any) {
@@ -159,11 +161,7 @@ export function getNodeProblems(pipeline: any, nodeDefinitions: any) {
       transformErrors
     ).errors;
     for (const error of errorMessages) {
-      const property =
-        error.property
-          ?.replace(".properties['", "")
-          ?.replace("'].required", "")
-          ?.replace(".", "") ?? "";
+      const property = getPropertyName(error.property ?? "");
       problems.push({
         message: error.message ?? "",
         path: error.params,

--- a/packages/pipeline-services/src/validation/index.ts
+++ b/packages/pipeline-services/src/validation/index.ts
@@ -14,20 +14,13 @@
  * limitations under the License.
  */
 
+import { ErrorTransformer, CustomValidator, FormValidation } from "@rjsf/utils";
+import validator from "@rjsf/validator-ajv6";
 import { parseTree, findNodeAtLocation } from "jsonc-parser";
 
 import checkCircularReferences from "./check-circular-references";
 import { PartialProblem, Problem } from "./types";
-import {
-  findNode,
-  getLinks,
-  getNodes,
-  getValue,
-  rangeForLocation,
-} from "./utils";
-
-import validator from "@rjsf/validator-ajv6";
-import { ErrorTransformer, CustomValidator, FormValidation } from "@rjsf/utils";
+import { findNode, getLinks, getNodes, rangeForLocation } from "./utils";
 
 export const transformErrors: ErrorTransformer = (errors) => {
   const newErrors = [];

--- a/packages/pipeline-services/src/validation/test-utils.ts
+++ b/packages/pipeline-services/src/validation/test-utils.ts
@@ -37,7 +37,6 @@ export const nodeSpec = {
             runtime_image: {
               type: "string",
               title: "Runtime Image",
-              required: true,
               description: "Container image used as execution environment.",
               uihints: { items: [] },
               enumNames: ["Anaconda (2021.11) with Python 3.x", "Pandas 1.4.1"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5756,20 +5756,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001196:
-  version "1.0.30001203"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001203.tgz"
-  integrity sha512-/I9tvnzU/PHMH7wBPrfDMSuecDeUKerjCPX7D0xBbaJZPxoT9m+yYxt0zCTkcijCkjTdim3H56Zm0i5Adxch4w==
-
-caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001181:
-  version "1.0.30001202"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz"
-  integrity sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ==
-
-caniuse-lite@^1.0.30001125:
-  version "1.0.30001296"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz"
-  integrity sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001181, caniuse-lite@^1.0.30001196:
+  version "1.0.30001422"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz"
+  integrity sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2738,20 +2738,20 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.2.tgz#830beaec4b4091a9e9398ac50f865ddea52186b9"
   integrity sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==
 
-"@rjsf/core@^5.0.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-5.1.0.tgz#431e45c273f51badbffe4359ff294d927852ff58"
-  integrity sha512-n2FeSk9iDuCF+Zo6nMLPuWsGsHCRiWnfohLNoyl1ll/tv6Ac5Oh0W3cwClIUEmJwaUFPaU/2O4ihFvSCdXwHlw==
+"@rjsf/core@~5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-5.0.2.tgz#1283cbdcfa8ed5ab2fb77609056e759d80fee7bc"
+  integrity sha512-uSb8PI08m2vFDlO86yuxdQd54MeTkgZUPzAFarL08j0QlAqiYLrTPqTkzbsldZ+pAPu+IRdOcQlBQ24gxztmsg==
   dependencies:
     lodash "^4.17.15"
     lodash-es "^4.17.15"
     nanoid "^3.3.4"
     prop-types "^15.7.2"
 
-"@rjsf/utils@^5.0.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@rjsf/utils/-/utils-5.1.0.tgz#d96dea755a17f8d5758c49b87ad125e0cb0a7426"
-  integrity sha512-b6ZPl5H+1trBitFUfNY9eBClfxsHqsRDtw6fwxSwdVgseAnb33kGxO+/0KLzDfSY2L0b2yOwKGY4kyHmpBUThQ==
+"@rjsf/utils@~5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@rjsf/utils/-/utils-5.0.2.tgz#1b5b4cc7532e524ec902111d4df0bc21fa1c8311"
+  integrity sha512-dOT6tiTdMwLueBhoT7s0HwF+D/CKlk3W6KBIaOyjezODeHgv+WKJ/F7GXvwXwdf9uJcizQ88HJJaG6PShiRNmQ==
   dependencies:
     json-schema-merge-allof "^0.8.1"
     jsonpointer "^5.0.1"
@@ -2759,12 +2759,12 @@
     lodash-es "^4.17.15"
     react-is "^18.2.0"
 
-"@rjsf/validator-ajv8@^5.0.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv8/-/validator-ajv8-5.1.0.tgz#e9c2cfa9c4aeec7df4ece7981701a31df4684a86"
-  integrity sha512-J3+cPT+saU2i4nOe8EDIMAWfrM4T48J8kgFL5O2mAObzlOI6O1UOSc0Rt82ag5zHhyAON0B6t0nG54/eDiCWfA==
+"@rjsf/validator-ajv8@~5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv8/-/validator-ajv8-5.0.2.tgz#4ff3cd0a8c445a59a876cecd4dcdf7865b848367"
+  integrity sha512-YmPW1+/O2VIq2hOnNyhh0cS1tVt6l/fdf7EpsnQhOcf69skF3PtjkpJJt0UHAG8Wt7Q2WSJ4SaDdH++D5BC6GQ==
   dependencies:
-    ajv "^8.12.0"
+    ajv "^8.11.0"
     ajv-formats "^2.1.1"
     lodash "^4.17.15"
     lodash-es "^4.17.15"
@@ -4579,7 +4579,7 @@ ajv@^7.0.2:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.12.0:
+ajv@^8.0.0, ajv@^8.11.0:
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2759,32 +2759,13 @@
     lodash-es "^4.17.15"
     react-is "^18.2.0"
 
-"@rjsf/utils@^5.0.0-beta.11":
-  version "5.0.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@rjsf/utils/-/utils-5.0.0-beta.11.tgz#bb8cce23fb3085e1484c63bb2373a9be5cdc60cf"
-  integrity sha512-PTzh+cj2PzGdpZERd00zWlAaYqYi9dL8apoUKHcBBBBBGd6yEd417NXUh5DOSzC7zXaY1i22MTrOIogdqiYukg==
-  dependencies:
-    json-schema-merge-allof "^0.8.1"
-    jsonpointer "^5.0.1"
-    lodash "^4.17.15"
-    lodash-es "^4.17.15"
-    react-is "^18.2.0"
-
-"@rjsf/validator-ajv6@^5.0.0":
+"@rjsf/validator-ajv8@^5.0.0":
   version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv6/-/validator-ajv6-5.1.0.tgz#77d9b9c6622a6f1f12749f690ee57c6be5236649"
-  integrity sha512-Oj1wXh/h4re8oj2R4tQR/u9CCIpLMBW0Y8zdl54uzSVbLicavhQ8hnmpEYjPrN8K76A09DYvL7r4k6QXqlR2AA==
+  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv8/-/validator-ajv8-5.1.0.tgz#e9c2cfa9c4aeec7df4ece7981701a31df4684a86"
+  integrity sha512-J3+cPT+saU2i4nOe8EDIMAWfrM4T48J8kgFL5O2mAObzlOI6O1UOSc0Rt82ag5zHhyAON0B6t0nG54/eDiCWfA==
   dependencies:
-    ajv "^6.7.0"
-    lodash "^4.17.15"
-    lodash-es "^4.17.15"
-
-"@rjsf/validator-ajv6@^5.0.0-beta.11":
-  version "5.0.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv6/-/validator-ajv6-5.0.0-beta.11.tgz#6ed02da1586dad9594434f131a7d84f4887428d3"
-  integrity sha512-LLKHGy5k8pwy7FnhmpbNJtnApyZe070sKpYqqm9o4fG8l9r8Me1AZ4yYXYeDEVOKDVrW9dnxAzYqc2J43Q5uog==
-  dependencies:
-    ajv "^6.7.0"
+    ajv "^8.12.0"
+    ajv-formats "^2.1.1"
     lodash "^4.17.15"
     lodash-es "^4.17.15"
 
@@ -4566,12 +4547,19 @@ ajv-errors@^1.0.0:
   resolved "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5, ajv@^6.7.0:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -4585,6 +4573,16 @@ ajv@^7.0.2:
   version "7.2.1"
   resolved "https://registry.npmjs.org/ajv/-/ajv-7.2.1.tgz"
   integrity sha512-+nu0HDv7kNSOua9apAVc979qd932rrZeb3WOvoiD31A/p1mIE5/9bN2027pE2rOPYEdS3UHzsvof4hY+lM9/WQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.12.0:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2738,20 +2738,20 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.2.tgz#830beaec4b4091a9e9398ac50f865ddea52186b9"
   integrity sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==
 
-"@rjsf/core@^5.0.0-beta.2":
-  version "5.0.0-beta.10"
-  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-5.0.0-beta.10.tgz#ff8f5f7da2f8509ae4d169746efd5cc7633e78cf"
-  integrity sha512-L/ZqK3/3uXhRLcvfOX3uL3adiJ0i7deV/egUkwnJQvqv1bIn58vY4wfiJwqTc8seiAHtyPCvehWZtLthyVP9Rw==
+"@rjsf/core@^5.0.0-beta.11":
+  version "5.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-5.0.0-beta.11.tgz#cebdbb7bc22bdbf5029cee253b56cc8d6d21577c"
+  integrity sha512-PEXoojuXz0GvQnFPhZ9G/YmabzYQ6Ywtx/PChDsBQkk0kJKeP9OLpe0Nxmw8cnQQ6V3IfaOVdsPHCXQrKE/PMg==
   dependencies:
     lodash "^4.17.15"
     lodash-es "^4.17.15"
     nanoid "^3.3.4"
     prop-types "^15.7.2"
 
-"@rjsf/utils@^5.0.0-beta.2":
-  version "5.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@rjsf/utils/-/utils-5.0.0-beta.2.tgz#4a6e6e0d931dbd969fda77c3c052d33a2567425a"
-  integrity sha512-ulUJRuksazVJ0NzuKQ1DvTN0SI/yEQsuufacrWhsNi3VG8bP9hb+7Y6tVO3T2WIayssvar5qpHHLeYND6LXoIQ==
+"@rjsf/utils@^5.0.0-beta.11":
+  version "5.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@rjsf/utils/-/utils-5.0.0-beta.11.tgz#bb8cce23fb3085e1484c63bb2373a9be5cdc60cf"
+  integrity sha512-PTzh+cj2PzGdpZERd00zWlAaYqYi9dL8apoUKHcBBBBBGd6yEd417NXUh5DOSzC7zXaY1i22MTrOIogdqiYukg==
   dependencies:
     json-schema-merge-allof "^0.8.1"
     jsonpointer "^5.0.1"
@@ -2759,12 +2759,11 @@
     lodash-es "^4.17.15"
     react-is "^18.2.0"
 
-"@rjsf/validator-ajv6@^5.0.0-beta.2":
-  version "5.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv6/-/validator-ajv6-5.0.0-beta.2.tgz#7b0f5995ea336ac528d43b436bce8073728fa515"
-  integrity sha512-QgkgTS/C2Z4Nr6lol1noocLrNBMbzKOj35uJ2EaWntopNXOKLZ2xeU3vaVDc4I59lh2wM+hmzFdMf39bTnRmzg==
+"@rjsf/validator-ajv6@^5.0.0-beta.11":
+  version "5.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv6/-/validator-ajv6-5.0.0-beta.11.tgz#6ed02da1586dad9594434f131a7d84f4887428d3"
+  integrity sha512-LLKHGy5k8pwy7FnhmpbNJtnApyZe070sKpYqqm9o4fG8l9r8Me1AZ4yYXYeDEVOKDVrW9dnxAzYqc2J43Q5uog==
   dependencies:
-    "@rjsf/utils" "^5.0.0-beta.2"
     ajv "^6.7.0"
     lodash "^4.17.15"
     lodash-es "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2738,15 +2738,26 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.2.tgz#830beaec4b4091a9e9398ac50f865ddea52186b9"
   integrity sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==
 
-"@rjsf/core@^5.0.0-beta.11":
-  version "5.0.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-5.0.0-beta.11.tgz#cebdbb7bc22bdbf5029cee253b56cc8d6d21577c"
-  integrity sha512-PEXoojuXz0GvQnFPhZ9G/YmabzYQ6Ywtx/PChDsBQkk0kJKeP9OLpe0Nxmw8cnQQ6V3IfaOVdsPHCXQrKE/PMg==
+"@rjsf/core@^5.0.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-5.1.0.tgz#431e45c273f51badbffe4359ff294d927852ff58"
+  integrity sha512-n2FeSk9iDuCF+Zo6nMLPuWsGsHCRiWnfohLNoyl1ll/tv6Ac5Oh0W3cwClIUEmJwaUFPaU/2O4ihFvSCdXwHlw==
   dependencies:
     lodash "^4.17.15"
     lodash-es "^4.17.15"
     nanoid "^3.3.4"
     prop-types "^15.7.2"
+
+"@rjsf/utils@^5.0.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@rjsf/utils/-/utils-5.1.0.tgz#d96dea755a17f8d5758c49b87ad125e0cb0a7426"
+  integrity sha512-b6ZPl5H+1trBitFUfNY9eBClfxsHqsRDtw6fwxSwdVgseAnb33kGxO+/0KLzDfSY2L0b2yOwKGY4kyHmpBUThQ==
+  dependencies:
+    json-schema-merge-allof "^0.8.1"
+    jsonpointer "^5.0.1"
+    lodash "^4.17.15"
+    lodash-es "^4.17.15"
+    react-is "^18.2.0"
 
 "@rjsf/utils@^5.0.0-beta.11":
   version "5.0.0-beta.11"
@@ -2758,6 +2769,15 @@
     lodash "^4.17.15"
     lodash-es "^4.17.15"
     react-is "^18.2.0"
+
+"@rjsf/validator-ajv6@^5.0.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv6/-/validator-ajv6-5.1.0.tgz#77d9b9c6622a6f1f12749f690ee57c6be5236649"
+  integrity sha512-Oj1wXh/h4re8oj2R4tQR/u9CCIpLMBW0Y8zdl54uzSVbLicavhQ8hnmpEYjPrN8K76A09DYvL7r4k6QXqlR2AA==
+  dependencies:
+    ajv "^6.7.0"
+    lodash "^4.17.15"
+    lodash-es "^4.17.15"
 
 "@rjsf/validator-ajv6@^5.0.0-beta.11":
   version "5.0.0-beta.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2738,21 +2738,15 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.2.tgz#830beaec4b4091a9e9398ac50f865ddea52186b9"
   integrity sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==
 
-"@rjsf/core@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-4.2.3.tgz#7ff2fb593f0af20485dc267391a8971378eec655"
-  integrity sha512-dRXhd1Tac/9OcG0VDrYDF2boNTyKINEEITEtJ4L1Yce2iMVk66U52BhWKIFp/WXDM27vwnOfwQo4NwGiqeQeHw==
+"@rjsf/core@^5.0.0-beta.2":
+  version "5.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-5.0.0-beta.10.tgz#ff8f5f7da2f8509ae4d169746efd5cc7633e78cf"
+  integrity sha512-L/ZqK3/3uXhRLcvfOX3uL3adiJ0i7deV/egUkwnJQvqv1bIn58vY4wfiJwqTc8seiAHtyPCvehWZtLthyVP9Rw==
   dependencies:
-    "@types/json-schema" "^7.0.7"
-    ajv "^6.7.0"
-    core-js-pure "^3.6.5"
-    json-schema-merge-allof "^0.6.0"
-    jsonpointer "^5.0.0"
     lodash "^4.17.15"
     lodash-es "^4.17.15"
-    nanoid "^3.1.23"
+    nanoid "^3.3.4"
     prop-types "^15.7.2"
-    react-is "16.9.0"
 
 "@rjsf/utils@^5.0.0-beta.2":
   version "5.0.0-beta.2"
@@ -3898,11 +3892,6 @@
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
-
-"@types/json-schema@^7.0.7":
-  version "7.0.11"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
-  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -6333,7 +6322,7 @@ compute-gcd@^1.2.1:
     validate.io-function "^1.0.2"
     validate.io-integer-array "^1.0.0"
 
-compute-lcm@^1.1.0, compute-lcm@^1.1.2:
+compute-lcm@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/compute-lcm/-/compute-lcm-1.1.2.tgz#9107c66b9dca28cefb22b4ab4545caac4034af23"
   integrity sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==
@@ -6561,11 +6550,6 @@ core-js-pure@^3.0.0:
   version "3.9.1"
   resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.9.1.tgz"
   integrity sha512-laz3Zx0avrw9a4QEIdmIblnVuJz8W51leY9iLThatCsFawWxC3sE4guASC78JbCin+DkwMpCdp1AVAuzL/GN7A==
-
-core-js-pure@^3.6.5:
-  version "3.23.2"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.23.2.tgz#efe5e486469c5ed2d088d76e973eb12e74a930e7"
-  integrity sha512-t6u7H4Ff/yZNk+zqTr74UjCcZ3k8ApBryeLLV4rYQd9aF3gqmjjGjjR44ENfeBMH8VVvSynIjAJ0mUuFhzQtrA==
 
 core-js-pure@^3.8.1, core-js-pure@^3.8.2:
   version "3.20.2"
@@ -11118,15 +11102,6 @@ json-schema-compare@^0.2.2:
   dependencies:
     lodash "^4.17.4"
 
-json-schema-merge-allof@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz#64d48820fec26b228db837475ce3338936bf59a5"
-  integrity sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==
-  dependencies:
-    compute-lcm "^1.1.0"
-    json-schema-compare "^0.2.2"
-    lodash "^4.17.4"
-
 json-schema-merge-allof@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz#ed2828cdd958616ff74f932830a26291789eaaf2"
@@ -11212,11 +11187,6 @@ jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
-
-jsonpointer@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.0.tgz#f802669a524ec4805fa7389eadbc9921d5dc8072"
-  integrity sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==
 
 jsonpointer@^5.0.1:
   version "5.0.1"
@@ -12410,6 +12380,11 @@ nanoid@^3.1.20, nanoid@^3.1.23:
   version "3.1.31"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.31.tgz#f5b58a1ce1b7604da5f0605757840598d8974dc6"
   integrity sha512-ZivnJm0o9bb13p2Ot5CpgC2rQdzB9Uxm/mFZweqm5eMViqOJe3PV6LU2E30SiLgheesmcPrjquqraoolONSA0A==
+
+nanoid@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -14346,11 +14321,6 @@ react-intl@*, react-intl@^5.0.0:
     intl-messageformat "9.5.3"
     intl-messageformat-parser "6.4.3"
     tslib "^2.1.0"
-
-react-is@16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
-  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
 react-is@17.0.2, react-is@^17.0.2:
   version "17.0.2"


### PR DESCRIPTION
Fixes elyra-ai/elyra#2933. Makes the validation consistent between rjsf and the pipeline-services package. 

Todo:
- [x] Shows validation error indicator for entire form
- [x] Tooltip broken for some nodes
- [x] Some extra validation indicators
- [x] Issue with switching oneOf option
- [x] Fix pipeline parameters validation error float says "Should be bool"
- [ ] Extra validation errors in tooltip
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

