### PR TITLE
Upgrade canvas and add enableMarkdownInComments flag

### DIFF
--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -21,7 +21,7 @@
     "link": "yarn link"
   },
   "dependencies": {
-    "@elyra/canvas": "^12.11.2",
+    "@elyra/canvas": "^12.23.2",
     "@elyra/pipeline-services": "^1.11.0",
     "@rjsf/core": "^4.2.3",
     "@rjsf/utils": "^5.0.0-beta.2",

--- a/packages/pipeline-editor/src/PipelineEditor/index.tsx
+++ b/packages/pipeline-editor/src/PipelineEditor/index.tsx
@@ -755,6 +755,7 @@ const PipelineEditor = forwardRef(
                 toolbarConfig={toolbar ?? []}
                 config={{
                   enableInternalObjectModel: true,
+                  enableMarkdownInComments: true,
                   emptyCanvasContent: children,
                   enablePaletteLayout: leftPalette ? "Flyout" : "None", // 'Flyout', 'None', 'Modal'
                   enableNodeFormatType: "Horizontal",

--- a/packages/pipeline-editor/src/common-canvas.d.ts
+++ b/packages/pipeline-editor/src/common-canvas.d.ts
@@ -109,6 +109,7 @@ declare module "@elyra/canvas" {
     toolbarConfig: any[];
     config: {
       enableInternalObjectModel?: boolean;
+      enableMarkdownInComments?: boolean;
       emptyCanvasContent?: any;
       enablePaletteLayout?: "Flyout" | "None" | "Modal";
       enableNodeFormatType?: "Horizontal";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1370,21 +1370,21 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz#d5e0706cf8c6acd8c6032f8d54070af261bbbb2f"
   integrity sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==
 
-"@elyra/canvas@^12.11.2":
-  version "12.11.2"
-  resolved "https://registry.yarnpkg.com/@elyra/canvas/-/canvas-12.11.2.tgz#dfdfbe1c0be666e60dd37f67b55d73a3983c5716"
-  integrity sha512-oPFGJX7OQl1X7YIpa5lyXdo9vTPNMhNQfZqeTuALlhfWFmiO+LAy8CBTo64DvYcsXkX4g1Io9dFap+UrNmsu1A==
+"@elyra/canvas@^12.23.2":
+  version "12.23.2"
+  resolved "https://registry.yarnpkg.com/@elyra/canvas/-/canvas-12.23.2.tgz#53b4c829135fb60e85971c3dc9a275ab7eaa164b"
+  integrity sha512-10Lkkwr0xlZsUBwhUoLbEo1Tl7cZ5gxW25wZWLo83z54JFZI4MxX413MMJMl3N3IPs0rOshl3qM12E/YXoozpw==
   dependencies:
     "@babel/runtime" "^7.16.3"
-    "@elyra/pipeline-schemas" "^3.0.48"
+    "@elyra/pipeline-schemas" "^3.0.63"
     codemirror "^5.58.2"
     d3 "^7.1.1"
     dagre "^0.8.5"
     date-fns "^2.28.0"
-    immutable "^4.0.0-rc.12"
-    immutable-undo "^2.0.0"
+    immutable "^4.0.0"
     jsonschema "^1.4.0"
     lodash "^4.17.21"
+    markdown-it "^13.0.1"
     prop-types "^15.7.2"
     react-codemirror2 "^7.2.1"
     react-contextmenu "^2.14.0"
@@ -1397,10 +1397,10 @@
     seedrandom "^3.0.5"
     uuid "^8.3.0"
 
-"@elyra/pipeline-schemas@^3.0.48":
-  version "3.0.52"
-  resolved "https://registry.yarnpkg.com/@elyra/pipeline-schemas/-/pipeline-schemas-3.0.52.tgz#9b2a19971ea15a80f556c27d05c31559a64250a9"
-  integrity sha512-8Vbpr5E3Psb0BDSFhQcpLlLEvixNOwB/rIJeMzTuM8k+D9xtvQlwcC+rGXtXKevoyD1HOwErXw+bNWRAoifGDg==
+"@elyra/pipeline-schemas@^3.0.63":
+  version "3.0.65"
+  resolved "https://registry.yarnpkg.com/@elyra/pipeline-schemas/-/pipeline-schemas-3.0.65.tgz#06e3952ac511062b8567e5289cbf53f99d33d02f"
+  integrity sha512-bUjFDOClsL5TypZ4wyctyPZ3HJyOzHWkY6LH2LIYmhEIZCvSA46FFMpDyZh7gxL+PMKaiznBdTDDArLn9399zA==
 
 "@emotion/cache@^10.0.27":
   version "10.0.29"
@@ -4757,6 +4757,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz"
@@ -7826,6 +7831,11 @@ entities@^2.0.0:
   resolved "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
+entities@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
+  integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
+
 env-paths@^2.2.0:
   version "2.2.1"
   resolved "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz"
@@ -9842,15 +9852,10 @@ immer@8.0.1, immer@9.0.7, immer@^9.0.7:
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.7.tgz#b6156bd7db55db7abc73fd2fdadf4e579a701075"
   integrity sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA==
 
-immutable-undo@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/immutable-undo/-/immutable-undo-2.0.0.tgz#34e42e89ad77b7fd53b0c183d7a002fda7bdec99"
-  integrity sha512-wRV9khfq+CkMNyGsz2YmUzv4ciPn0qM/Zhl7/OGviby7Bd70opOr/wfN/oFTyX7hXRolyfjZESJDDCKAlSNNUw==
-
-immutable@^4.0.0-rc.12:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0.tgz#b86f78de6adef3608395efb269a91462797e2c23"
-  integrity sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==
+immutable@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.1.0.tgz#f795787f0db780183307b9eb2091fcac1f6fafef"
+  integrity sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==
 
 import-cwd@^3.0.0:
   version "3.0.0"
@@ -11363,6 +11368,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+linkify-it@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-4.0.1.tgz#01f1d5e508190d06669982ba31a7d9f56a5751ec"
+  integrity sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==
+  dependencies:
+    uc.micro "^1.0.1"
+
 lint-staged@^9.4.3:
   version "9.5.0"
   resolved "https://registry.npmjs.org/lint-staged/-/lint-staged-9.5.0.tgz"
@@ -11836,6 +11848,17 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
+markdown-it@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-13.0.1.tgz#c6ecc431cacf1a5da531423fc6a42807814af430"
+  integrity sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==
+  dependencies:
+    argparse "^2.0.1"
+    entities "~3.0.1"
+    linkify-it "^4.0.1"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 markdown-to-jsx@^7.1.3:
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.5.tgz#caf72ad8a8c34a2bb692c4d17e44aabbe4eb19fd"
@@ -11903,7 +11926,7 @@ mdn-data@2.0.4:
   resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-mdurl@^1.0.0:
+mdurl@^1.0.0, mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
@@ -16708,6 +16731,11 @@ typescript@^4.1.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz"
   integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-js@^3.1.4:
   version "3.13.1"


### PR DESCRIPTION
Fixes elyra-ai/elyra#3014 - upgrades canvas and adds the capability to render markdown in comments in the canvas:
![image](https://user-images.githubusercontent.com/6673460/202010092-6cd0c3c6-2619-46fb-b9a8-7fbda9461790.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

